### PR TITLE
Added citation for PSA (MDAnalysis Issue #545)

### DIFF
--- a/pages/citations.md
+++ b/pages/citations.md
@@ -70,8 +70,8 @@ If you use the Path Similarity Analysis (PSA) code in
 please cite
 
  * Seyler SL, Kumar A, Thorpe MF, Beckstein O (2015) Path Similarity
-   Analysis: A Method for Quantifying Macromolecular Pathways. PLoS
-   Comput Biol 11(10): e1004568. doi: [10.1371/journal.pcbi.1004568](http://dx.doi.org/10.1371/journal.pcbi.1004568)
+   Analysis: A Method for Quantifying Macromolecular Pathways. *PLoS
+   Comput Biol* **11**(10): e1004568. doi: [10.1371/journal.pcbi.1004568](http://dx.doi.org/10.1371/journal.pcbi.1004568)
 
 Thanks!
 


### PR DESCRIPTION
Note that the PLOS Computational Biology citation formatting is different from what is used for other citations in `citations.md`, but the boldface for the volume number and italics for the journal name was added for visual clarity. The existing citations do not currently have a consistent format for author names (first vs last name first, periods for abbreviated first names, etc.)
