### PR TITLE
Made sidebar blog link check more generic

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -17,12 +17,14 @@
         `layout: page` in the front-matter. See readme for usage.
       {% endcomment %}
 
+      {% assign blogpagedir = site.paginate_path | split: ":" | first %}
+      {% assign blogpagedir_len = blogpagedir | size %}
       {% assign pages_list = site.pages %}
       {% for node in pages_list %}
         {% if node.title != null %}
           {% if node.layout == "page" %}
-            {% assign prefix = node.url | truncate: 10, '' %}
-            {% if prefix != "/blog/page" %}
+            {% assign prefix = node.url | truncate: blogpagedir_len, '' %}
+            {% if prefix != blogpagedir %}
               <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ node.url }}">{{ node.title }}</a>
             {% endif %}
           {% endif %}


### PR DESCRIPTION
Good point @orbeckst. This should do it (notice I now fish directly `site.paginate_path`, which is potentially different from `site.blog/page`).