### PR TITLE
Conda (fixes #20)

### DIFF
--- a/_posts/2016-03-19-conda.md
+++ b/_posts/2016-03-19-conda.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title: Official Conda Builds
+---
+
+Starting today MDAnalysis is officially building [conda][conda] packages. The
+package will be published to the [MDAnalysis organization][mda-channel] on
+[anaconda.org][anaconda]. The conda package includes the MDAnalysis packages as
+well as the MDAnalysisTests package.
+
+To install MDAnalysis with conda use:
+
+    conda config --add channels MDAnalysis
+    conda install mdanalysis
+
+If you later want to update to the next release use:
+
+    conda update mdanalysis
+
+Currently we only support linux 64bit builds for conda. OSX users still have to
+use [pip][pip]. We plan to support OSX in the future as well, we'd appreciate
+any help here.
+
+The [GridDataFormats][gridData] package is also available through conda on OSX
+and linux.
+
+- @kain88-de
+
+[conda]: https://github.com/conda/conda
+[anaconda]: https://anaconda.org
+[mda-channel]: https://anaconda.org/MDAnalysis
+[pip]: {{site.baseurl}}pages/installation_quick_start
+[gridData]: https://github.com/MDAnalysis/GridDataFormats

--- a/_posts/2016-03-19-conda.md
+++ b/_posts/2016-03-19-conda.md
@@ -4,7 +4,7 @@ title: Official Conda Builds
 ---
 
 Starting today MDAnalysis is officially building [conda][conda] packages. The
-package will be published to the [MDAnalysis organization][mda-channel] on
+package are published in the [MDAnalysis organization][mda-channel] on
 [anaconda.org][anaconda]. The conda package includes the MDAnalysis packages as
 well as the MDAnalysisTests package.
 
@@ -18,13 +18,13 @@ If you later want to update to the next release use:
     conda update mdanalysis
 
 Currently we only support linux 64bit builds for conda. OSX users still have to
-use [pip][pip]. We plan to support OSX in the future as well, we'd appreciate
+use [pip][pip]. We plan to support OSX in the future as well; we'd appreciate
 any help here.
 
 The [GridDataFormats][gridData] package is also available through conda on OSX
 and linux.
 
-- @kain88-de
+--- @kain88-de
 
 [conda]: https://github.com/conda/conda
 [anaconda]: https://anaconda.org

--- a/pages/installation_quick_start.md
+++ b/pages/installation_quick_start.md
@@ -3,8 +3,10 @@ layout: page
 title: Installation Quick Start
 ---
 
-To install the latest stable release, use
-[pip](http://www.pip-installer.org/en/latest/index.html):
+# Python Package Index
+
+To install the latest stable release with
+[pip][pip] do:
 
 {% highlight bash %}
 pip install --upgrade MDAnalysis
@@ -17,6 +19,27 @@ in size):
 pip install --upgrade MDAnalysisTests
 {% endhighlight %}
 
+# Conda
+
+To install the lastest stable release with [conda][conda] do:
+
+{% highlight bash %}
+conda config --add channels MDAnalysis
+conda install mdanalysis
+{% endhighlight %}
+
+To upgrade to the latest stable release.
+
+{% highlight bash %}
+conda update mdanalysis
+{% endhighlight %}
+
+The conda packages currently only support serial distance calculations. If you
+plan to use the parralel openMP algorithms you need to install MDAnalysis with
+[pip][pip] and have a working openMP installation.
+
+# More
+
 For more details on installation and alternative ways to install MDAnalysis
 (e.g. through your distribution's package manager, see [Installing
 MDAnalysis]({{site.github.wiki}}/Install)).
@@ -24,3 +47,6 @@ MDAnalysis]({{site.github.wiki}}/Install)).
 If you have questions with the installation, please ask on the
 [{{site.mailinglists.discussion.name}}]({{site.mailinglists.discussion.url}})
 mailing list.
+
+[pip]: http://www.pip-installer.org/en/latest/index.html
+[conda]: https://github.com/conda/conda

--- a/pages/installation_quick_start.md
+++ b/pages/installation_quick_start.md
@@ -34,9 +34,9 @@ To upgrade to the latest stable release.
 conda update mdanalysis
 {% endhighlight %}
 
-The conda packages currently only support serial distance calculations. If you
-plan to use the parralel openMP algorithms you need to install MDAnalysis with
-[pip][pip] and have a working openMP installation.
+The conda packages currently only support serial calculations. If you
+plan to use the parallel [OpenMP][OpenMP] algorithms you need to install
+MDAnalysis with [pip][pip] and have a working OpenMP installation.
 
 # More
 
@@ -49,4 +49,5 @@ If you have questions with the installation, please ask on the
 mailing list.
 
 [pip]: http://www.pip-installer.org/en/latest/index.html
-[conda]: https://github.com/conda/conda
+[conda]: http://conda.pydata.org/docs/
+[OpenMP]: http://openmp.org


### PR DESCRIPTION
Fixes #20 

After merging the build instructions it's time to make the conda build official. Here is the release text for the blog post and the changed quick install instructions.