### PR TITLE
blog post for CoC

### DIFF
--- a/_posts/2017-02-09-CoC.md
+++ b/_posts/2017-02-09-CoC.md
@@ -6,7 +6,9 @@ title: Our Code of Conduct
 
 Dear MDAnalysis Community,
 
-MDAnalysis has adopted a
+We feel the MDAnalysis community is a happy one, and we hope all members
+feel the same. As the community grows we want it to stay as welcoming.
+In that spirit, MDAnalysis has adopted a
 [Code of Conduct]({{site.baseurl}}pages/conduct/) (CoC) to make
 explicit that we as a community value *all* our present and future
 members and embrace our diversity. We are committed to providing a

--- a/_posts/2017-02-09-CoC.md
+++ b/_posts/2017-02-09-CoC.md
@@ -35,8 +35,8 @@ feel uncomfortable then please speak up: the CoC has links to
 [communicate safely]({{site.baseurl}}pages/conduct/#reporting) with a
 subset of the core developers who have taken on the responsibility to
 follow up on CoC violations. If you observe that someone else is being
-harassed please speak up – during the incident, if possible, and
-definitely through the above channels.
+harassed please speak up – during the incident, if possible, or
+through the above channels.
 
 Establishing the CoC was not prompted by any incident. Rather, the
 core developers recognized that the best time to make explicit the

--- a/_posts/2017-02-09-CoC.md
+++ b/_posts/2017-02-09-CoC.md
@@ -1,0 +1,45 @@
+---
+layout: post
+title: Our Code of Conduct
+---
+
+
+Dear MDAnalysis Community,
+
+MDAnalysis has adopted a
+[Code of Conduct]({{site.baseurl}}pages/conduct/) (CoC) to make
+explicit that we as a community value *all* our present and future
+members and embrace our diversity. We are committed to providing a
+productive, harassment-free environment for everyone
+
+Please read the full text at
+[http://mdanalysis.org/pages/conduct/]({{site.baseurl}}pages/conduct/).
+
+All core developers absolutely stand behind the CoC and are fully
+committed to ensuring and enforcing that *everyone* (founders,
+developers, anyone communicating on the lists or on GitHub, ...)
+respects each other as outlined in the CoC.
+
+But it's not only core developers who are responsible for making our's
+an inclusive community in which everyone feels they can productively
+participate. It actually need to be *all of us*. A community is based on
+the interactions of individuals and the sum of their values defines
+their community. The CoC means that everyone in MDAnalysis agrees to
+share a common set of core values and, importantly, to act according
+to these values in all interactions in our community.
+
+If you feel you suffered from harassment or intimidation or were made
+feel uncomfortable then please speak up: the CoC has links to
+[communicate safely]({{site.baseurl}}pages/conduct/#reporting) with a
+subset of the core developers who have taken on the responsibility to
+follow up on CoC violations. If you observe that someone else is being
+harassed please speak up – during the incident, if possible, and
+definitely through the above channels.
+
+Establishing the CoC was not prompted by any incident. Rather, the
+core developers recognized that the best time to make explicit the
+rules and values of our community is simply a good idea, and we follow
+many of the major open source projects such as Django and Jupyter
+(from which we heavily borrowed – [thank you]({{site.baseurl}}pages/conduct/#acknowledgment)!).
+
+— [@MDAnalysis/coredevs](https://github.com/orgs/MDAnalysis/teams/coredevs)

--- a/_posts/2017-02-09-CoC.md
+++ b/_posts/2017-02-09-CoC.md
@@ -39,9 +39,10 @@ harassed please speak up – during the incident, if possible, or
 through the above channels.
 
 Establishing the CoC was not prompted by any incident. Rather, the
-core developers recognized that the best time to make explicit the
-rules and values of our community is simply a good idea, and we follow
-many of the major open source projects such as Django and Jupyter
-(from which we heavily borrowed – [thank you]({{site.baseurl}}pages/conduct/#acknowledgment)!).
+core developers recognized that making explicit the rules and values
+of our community is simply a good idea, and we follow many of the
+major open source projects such as Django and Jupyter (from which we
+heavily borrowed –
+[thank you]({{site.baseurl}}pages/conduct/#acknowledgment)!).
 
 — [@MDAnalysis/coredevs](https://github.com/orgs/MDAnalysis/teams/coredevs)


### PR DESCRIPTION
The [Code of Conduct](http://www.mdanalysis.org/pages/conduct/) needs to be properly announced so that EVERYONE knows that this is now the basis for our interactions.
- introduction and background for new CoC #34 
- will also be sent to mailing lists
- should also be tweeted 

@MDAnalysis/coredevs please have a look.