### PR TITLE
use clearer language for license

### DIFF
--- a/about.md
+++ b/about.md
@@ -43,11 +43,11 @@ mailing list]({{site.mailinglists.discussion.url}}).
 
 # Availability
 
-All source code is available under the [GNU General Public License,
-version 2](https://www.gnu.org/licenses/gpl-2.0.html) (or an open
-source licence compatible with GPLv2) from
-[github.com/MDAnalysis](https://github.com/MDAnalysis) and the Python
-Package index
+All source code is available under the
+[GNU General Public License, version 2](https://www.gnu.org/licenses/gpl-2.0.html)
+(or any later version at your choice) from
+[github.com/MDAnalysis/mdanalysis](https://github.com/MDAnalysis/mdanalysis)
+and the Python Package index
 [pypi.python.org/pypi/MDAnalysis](http://pypi.python.org/pypi/MDAnalysis).
 
 

--- a/index.md
+++ b/index.md
@@ -37,12 +37,13 @@ updates and events.
 
 ### Availability
 
-All source code is available under the [GNU General Public License,
-version 2](https://www.gnu.org/licenses/gpl-2.0.html) (or an open
-source licence compatible with GPLv2) from
-[github.com/MDAnalysis](https://github.com/MDAnalysis) and the Python
-Package index
+All source code is available under the
+[GNU General Public License, version 2](https://www.gnu.org/licenses/gpl-2.0.html)
+(or any later version at your choice) from
+[github.com/MDAnalysis/mdanalysis](https://github.com/MDAnalysis/mdanalysis)
+and the Python Package index
 [pypi.python.org/pypi/MDAnalysis](http://pypi.python.org/pypi/MDAnalysis).
+
 
 ### Participating
 


### PR DESCRIPTION
- fixes #39
- make clear that EVERYTHING is GPL v2 (or later); legally, by including code
  under more permissive licenses we also put it under GPLv2 (that's what the GPL does)
  but because that code exists under permissive licenses separate from MDA, users
  can still use it under that permissive license