### PR TITLE
Roadmap

### DIFF
--- a/_posts/2019-11-06-roadmap.md
+++ b/_posts/2019-11-06-roadmap.md
@@ -1,0 +1,64 @@
+---
+layout: post
+title: Roadmap
+---
+
+Python 2 reaches end of life on 1 January, 2020, according to [PEP
+373](https://www.python.org/dev/peps/pep-0373/) and
+[python/devguide#344](https://github.com/python/devguide/pull/344). Many
+of our dependencies (notably numpy, see their [Plan for dropping
+Python 2.7
+support](https://docs.scipy.org/doc/numpy-1.14.0/neps/dropping-python2.7-proposal.html))
+have ceased Python 2.7 support in new releases or will also drop
+Python 2.7 in 2020.
+
+We know that science is rolling slowly and surely some scientific
+projects will continue with Python 2.7 beyond 2020. MDAnalysis has
+been supporting Python 2 and Python 3 now for a while. However, given
+how precious developer time is, we also decided to drop support soon
+after the official Python 2.7 drop date. 
+
+Our plan is to give researchers a stable legacy platform and release
+**MDAnalysis 1.0.0** with full Python 2.7 support and tests. However,
+no major development will continue in 1.0. Issues will only be fixed
+and backported on a best-effort basis, simply because there are not
+enough developers to do this work.
+
+We will then work towards **MDAnalysis 2.0.0**,  which will
+only support Python 3.
+
+
+
+## Tentative Roadmap
+### 2020 (1st quarter)
+
+- release **1.0.0** in early 2020 (maybe end of 2019...)
+   - 1.x will be the last version of MDAnalysis that fully supports Python 2.7
+   - 1.0 will be similar to upcoming 0.21 (i.e., no  major annoying
+        API breaks but clean-up and deprecations)
+   - development on 1.x will cease with the release of 2.0; we will
+     consider PRs that backport fixes but we will not officially
+     support it after the release of 2.0
+- finalize API decisions for 2.0.0
+
+### 2020 (2nd quarter)
+
+- release **2.0.0**
+    - officially drop Python 2.7 support
+    - support all current Python 3.x releases	
+	- include larger changes/deprecations (API breaks compared to
+      1.0.0 if necessary, removal of legacy code, etc)
+- code modernization (making use of specific Python 3 constructs) will
+  be ongoing
+
+
+## Comments?
+
+If you have comments or you see problems with this roadmap then please
+get in touch
+- [Issue #2303](https://github.com/MDAnalysis/mdanalysis/issues/2303)
+- Twitter [@{{ site.twitter.name }}]({{ site.twitter.url }})
+- mailing list [{{ site.mailinglists.discussion.name }}]({{ site.mailinglists.discussion.url }})
+  
+— [@MDAnalysis/coredevs](https://github.com/orgs/MDAnalysis/teams/coredevs)
+


### PR DESCRIPTION
Close #111 

Discontinue Py2 support after 1.0 and start 2.0 soon after.

See https://github.com/MDAnalysis/mdanalysis/issues/2303 for larger discussion.