### PR TITLE
update governance section in About

### DIFF
--- a/about.md
+++ b/about.md
@@ -58,7 +58,7 @@ of current MDAnalysis Core Developers.
 All decisions by the MDAnalysis Core Developers are made by simple majority.
 
 A rotating subset of three MDAnalysis Core Developers is tasked to respond to and to
-investigate Code of Conduct violations.
+investigate [Code of Conduct]({{site.baseurl}}/pages/conduct/) violations.
 
 
 ## Partners
@@ -80,7 +80,7 @@ Foundation](https://www.nsf.gov/) and [NumFOCUS](https://www.numfocus.org).
 	
 <img
 	src="https://developers.google.com/open-source/gsoc/images/gsoc2016-sun-373x373.png"
-	title="Google Summer of Code 2018" alt="Google Summer of Code 2018"
+	title="Google Summer of Code" alt="Google Summer of Code"
 	style="display: inline; float: left; height: 4em;" />
 
 <img src="{{site.images}}/nsf.jpg" title="National Science Foundation"

--- a/about.md
+++ b/about.md
@@ -55,7 +55,7 @@ lists. MDAnalysis Core Developers are granted commit rights (write access) to th
 source code repository. New MDAnalysis Core Developers are elected with a simple majority
 of current MDAnalysis Core Developers.
 
-All decisions by the MDAnalysis Core Developers are made by simple majority.
+All decisions are made by simple majority of the MDAnalysis Core Developers.
 
 A rotating subset of three MDAnalysis Core Developers is tasked to respond to and to
 investigate [Code of Conduct]({{site.baseurl}}/pages/conduct/) violations.

--- a/about.md
+++ b/about.md
@@ -46,19 +46,18 @@ Installable packages are available through the popular ``pip`` and
 
 ## Governance
 
-Project leadership is currently provided by a subset of contributors, the *Core
-Developers*
+Project leadership is currently provided by a subset of contributors,
+the *MDAnalysis Core Developers*
 ([@MDAnalysis/coredevs](https://github.com/orgs/MDAnalysis/teams/coredevs)) who
 have produced substantial contributions over extended lengths of time and who
 remain active in reviewing issues and discussions on the various mailing
-lists. Core Developers are granted commit rights (write access) to the GitHub
-source code repository. New Core Developers are elected with a simple majority
-of current Core Developers.
+lists. MDAnalysis Core Developers are granted commit rights (write access) to the GitHub
+source code repository. New MDAnalysis Core Developers are elected with a simple majority
+of current MDAnalysis Core Developers.
 
-*In general, all project decisions are made through consensus among the Core
-Developers.*
+All decisions by the MDAnalysis Core Developers are made by simple majority.
 
-A rotating subset of three Core Developers is tasked to respond to and to
+A rotating subset of three MDAnalysis Core Developers is tasked to respond to and to
 investigate Code of Conduct violations.
 
 


### PR DESCRIPTION
- updates as agreed by vote in issue #113 
   - name project leadership "MDAnalysis Core Developers"
   - update: decisions are made with simple majority
- minor change: link to CoC, rephrased decision making procedure