### PR TITLE
privacy policy

### DIFF
--- a/index.md
+++ b/index.md
@@ -66,8 +66,26 @@ GitHub](https://github.com/MDAnalysis/mdanalysis#fork-destination-box)
 and submit a pull request. Participate on the [{{site.mailinglists.developer.name}}
 mailing list]({{site.mailinglists.developer.url}}).
 
+
+### Supporting
+
+If you like MDAnalysis and want to support our mission, please
+consider making a donation to support our efforts.
+
+{{ site.numfocus.donate_button }}
+
+(Donations are made through [our fiscal sponsor][], [NumFOCUS][], which is
+a 501(c)(3) non-profit charity in the United States; as such,
+donations to NumFOCUS are tax-deductible as allowed by law.  As with
+any donation, you should consult with your personal tax adviser or the
+IRS about your particular tax situation.)
+
 <a href="https://github.com/MDAnalysis/mdanalysis"><img style="position: absolute; top:
 0; right: 0; border: 0;"
 src="https://camo.githubusercontent.com/a6677b08c955af8400f44c6298f40e7d19cc5b2d/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67"
 alt="Fork me on GitHub"
 data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png"></a>
+
+
+[NumFOCUS]: https://www.numfocus.org
+[our fiscal sponsor]: {{site.baseurl}}/about#partners

--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -1,0 +1,67 @@
+---
+layout: page
+title: Privacy Policy
+---
+
+MDAnalysis is a [fiscally sponsored
+project]({{site.numfocus.sponsored_project}}) of [NumFOCUS][], a nonprofit
+dedicated to supporting the open source scientific computing
+community. Like NumFOCUS, we value the privacy of our users.
+
+
+## NumFOCUS Privacy Policy
+
+**All MDAnalysis websites are legally governed by the [NumFOCUS
+Privacy Policy][]**, which can be found at
+[https://numfocus.org/privacy-policy](https://numfocus.org/privacy-policy).
+
+The sections below explain how MDAnalysis processes and collects data,
+which differs from sites of the NumFOCUS organization.
+
+
+## What information does MDAnalysis collect?
+
+We only collect anonymous per-page *usage statistics* using
+[GoatCounter][] with details explained in the [GoatCounter privacy
+policy][]. These statistics are publicly visible at
+[https://mdanalysis.goatcounter.com](https://mdanalysis.goatcounter.com/).
+
+*Online payments* (donations) are processed through NumFOCUS; as soon
+as you follow a "donate" button or link on a MDAnalysis website, you
+will be transferred to a NumFOCUS site. Please see the [NumFOCUS
+Privacy Policy][] regarding data collected during payment processing.
+
+
+## Who will your information be shared with?
+
+We only share information with the following third parties:
+
+* Cloud computing services:
+  [Cloudflare](https://www.cloudflare.com). Requests are routed
+  through Cloudflare's caches and DNS resolvers; please see
+  [https://www.cloudflare.com/privacypolicy](https://www.cloudflare.com/privacypolicy)
+  for how Cloudflare collects information.
+* Search: [algolia](https://www.algolia.com/) provides search
+  functionality. Your search terms are transmitted to algolia to
+  provide the search functionality on our site. Please see
+  [https://www.algolia.com/policies/privacy](https://www.algolia.com/policies/privacy/)
+  under Section *9. Subscriber Data submitted to our Services or collected through
+  our Services (on behalf of our subscribers)* to learn how algolia
+  uses your data.
+* Usage statistics: [GoatCounter][] collects
+  anonymous page visit statistics, as explained in
+  [https://www.goatcounter.com/privacy](https://www.goatcounter.com/privacy).
+* Website hosting: [GitHub](https://github.com/) hosts the web pages
+  as GitHub Pages; please see GitHub's privacy policy
+  [https://help.github.com/en/github/site-policy/github-privacy-statement#additional-services](https://help.github.com/en/github/site-policy/github-privacy-statement#additional-services)
+  regarding accessing GitHub Pages.
+* Payment processing: all payment processing is completely handled by
+  [NumFOCUS][] and their partners, as described in their privacy policy
+  [https://numfocus.org/privacy-policy](https://numfocus.org/privacy-policy).
+  
+
+
+[NumFOCUS]: https://www.numfocus.org
+[NumFOCUS Privacy Policy]: https://numfocus.org/privacy-policy
+[GoatCounter]: https://www.goatcounter.com/
+[GoatCounter privacy policy]: https://www.goatcounter.com/privacy


### PR DESCRIPTION
Fix #129 

- adds a normal page with the privacy policy (which shows up in the menu and not in any special place)
- links to https://numfocus.org/privacy-policy, which legally governs all MDAnalysis sites; this is based on advice from NumFOCUS
- explain what information we gather (very little thanks to the removal of Google Analytics #131) and what our 3rd party providers are
