### PR TITLE
NF edits to privacy.md

### DIFF
--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -6,17 +6,12 @@ title: Privacy Policy
 MDAnalysis is a [fiscally sponsored
 project]({{site.numfocus.sponsored_project}}) of [NumFOCUS][], a nonprofit
 dedicated to supporting the open source scientific computing
-community. Like NumFOCUS, we value the privacy of our users.
-
-
-## NumFOCUS Privacy Policy
-
-**All MDAnalysis websites are legally governed by the [NumFOCUS
-Privacy Policy][]**, which can be found at
+community. Like NumFOCUS, we value the privacy of our users. **We comply 
+with the [NumFOCUS Privacy Policy][]**, which can be found at
 [https://numfocus.org/privacy-policy](https://numfocus.org/privacy-policy).
 
-The sections below explain how MDAnalysis processes and collects data,
-which differs from sites of the NumFOCUS organization.
+The sections below explain additional processes and data collection 
+policies specific to MDAnalysis. 
 
 
 ## What information does MDAnalysis collect?
@@ -28,10 +23,10 @@ policy][]. These statistics are publicly visible at
 You can *disable statistics collection* by blocking the JavaScript
 coming from *gc.zgo.at*.
 
-*Online payments* (donations) are processed through NumFOCUS; as soon
-as you follow a "donate" button or link on a MDAnalysis website, you
-will be transferred to a NumFOCUS site. Please see the [NumFOCUS
-Privacy Policy][] regarding data collected during payment processing.
+*Online payments* (donations) are processed through NumFOCUS; upon clicking 
+on a "donate" button or link, you will be transferred to a NumFOCUS site. 
+Please see the [NumFOCUS Privacy Policy][] regarding data collected during 
+payment processing.
 
 
 ## Who will your information be shared with?
@@ -60,9 +55,6 @@ We only share information with the following third parties:
   as GitHub Pages; please see GitHub's privacy policy
   [https://help.github.com/en/github/site-policy/github-privacy-statement#additional-services](https://help.github.com/en/github/site-policy/github-privacy-statement#additional-services)
   regarding accessing GitHub Pages.
-* Payment processing: all payment processing is completely handled by
-  [NumFOCUS][] and their partners, as described in their privacy policy
-  [https://numfocus.org/privacy-policy](https://numfocus.org/privacy-policy).
   
 
 


### PR DESCRIPTION
These are NumFOCUS' wording suggestions for referring to our privacy policy. This is tricky because legally we are the same entity but we still need to make it clear that MDAnalysis has some autonomy with data processing. I hope this sounds okay. 😄