### PR TITLE
Update links to quickstart

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -77,7 +77,7 @@ docs:
     url:          https://userguide.mdanalysis.org
   quickstart:
     name:         Quick Start Guide
-    url:          https://userguide.mdanalysis.org/examples/quickstart.html
+    url:          https://userguide.mdanalysis.org/stable/quickstart.html
 
 algolia:
   index_name: mdanalysis

--- a/_posts/2020-02-22-gsoc2020.md
+++ b/_posts/2020-02-22-gsoc2020.md
@@ -113,8 +113,8 @@ and answers as we are moving towards the application deadline.
 [own requirements]: {{ site.github.wiki }}/Google-Summer-Of-Code#our-expectations-from-students
 [easy bugs]: https://github.com/MDAnalysis/mdanalysis/issues?q=is%3Aopen+is%3Aissue+label%3ADifficulty-easy
 [GSOC Starter]: https://github.com/MDAnalysis/mdanalysis/issues?q=is%3Aopen+is%3Aissue+gsoc+label%3A%22GSOC+Starter%22
-[Quick Start Guide]: https://www.mdanalysis.org/UserGuide/examples/quickstart.html
-[User Guide]: https://www.mdanalysis.org/UserGuide
+[Quick Start Guide]: https://userguide.mdanalysis.org/stable/quickstart.html
+[User Guide]: https://userguide.mdanalysis.org/
 [ideas]: {{ site.github.wiki }}/Project-Ideas-2020
 [gsoc]: https://summerofcode.withgoogle.com/
 [dev-guide]: https://www.mdanalysis.org/UserGuide/contributing.html


### PR DESCRIPTION
When I moved the quickstart guide to a top-level URL (see https://github.com/MDAnalysis/UserGuide/issues/109), I inadvertently broke the links on the website (see https://github.com/MDAnalysis/mdanalysis/issues/3090). This PR fixes that.