### PR TITLE
Add LiPyphilic to used-by.md

### DIFF
--- a/pages/used-by.md
+++ b/pages/used-by.md
@@ -55,6 +55,7 @@ can include them here* or open a pull request by [editing the file `used-by.md`]
    interfacial and confined systems.
 -  [taurenmd](https://taurenmd.readthedocs.io/en/latest/): A command-line interface for analysis of Molecular Dynamics simulations.
 -  [PENSA](https://github.com/drorlab/pensa): A toolkit for exploratory analysis and comparison of protein structural ensembles
+-  [LiPyphilic](https://lipyphilic.readthedocs.io/en/latest/): A Python package for the analysis of lipid membrane simulations.
 
 ## Molecular modeling tools
 


### PR DESCRIPTION
Hi,

I'd like to add [LiPyphilic](https://lipyphilic.readthedocs.io/en/latest/) to the "used by" page. It's a Python package for analysing MD simulations of lipid membranes, and is based on MDAnalysis. It's essentially a bunch of analysis tools that each use the MDAnalysis base analysis class, plus there are a couple of trajectory transformations.
