### PR TITLE
fixed blogpost

### DIFF
--- a/_posts/2021-05-02-release-1.x.x.md
+++ b/_posts/2021-05-02-release-1.x.x.md
@@ -103,7 +103,7 @@ For the full list of fixed please see the [CHANGELOG][]. The following are selec
 
 ### Core
 
-- Neighbor searching, which is a fundamental component of many analyses in MDAnalysis (such as hydrogenbonds and RDF calculation) had a number of bugs in 1.0.0 that could lead to wrong results, in particular with triclinic unit cells. The buggy code was disabled in 1.0.1 and fixed in 1.1.1. See issues [#2229][], [#2345][], [#2919][], [#2670][] [#2930][] for details.
+- Neighbor searching, which is a fundamental component of many analyses in MDAnalysis (such as hydrogenbonds and RDF calculation) had a number of bugs in 1.0.0 that could lead to wrong results, in particular with triclinic unit cells. The buggy code was disabled in 1.0.1 and fixed in 1.1.1. See issues [#2229][], [#2345][], [#2919][], [#2670][], [#2930][] for details.
 - Fixed a SegmentationFault for the selection "around 0.0 SELECTION" (Issue [#2656][])
 - `AtomGroup.center()` now works correctly for compounds and unwrapping (Issue [#2984][])
 - When bonds are guessed from distances (`AtomGroup.guess_bonds`), periodic boundary information is properly taken into account. Bonds that were split across the periodic boundary would have not beend correctly guessed previously. (Issue [#2350][])
@@ -116,7 +116,7 @@ For the full list of fixed please see the [CHANGELOG][]. The following are selec
     - When a PDB file is read, a cryo-em 1 Å<sup>3</sup> default CRYST1 record will be interpreted as "no dimensions" and the box dimension in MDAnalysis is set to ``None`` (Issue [#2599][])
     - When box dimensions are missing (`u.dimensions` is `None` or `np.zeros(6)`) then a  unitary `CRYST1` record (cubic box with sides of 1 Å) is written (Issue [#2679][])
   - PDB files no longer lose chainIDs when reading files without segIDs (Issue [#2389][])
-  - PDBWriter now uses first character of segid as ChainID (Issue [#2224][])
+  - PDBWriter now uses last character of segid as ChainID (Issue [#2224][])
 - In **GRO** files, unit cells with box vectors larger than 1000 nm are now correctly handled (Issue [#2371][])
 - Reading of **XTC** and **TRR** files will not anymore fail with an `IOError` when the hidden offset files cannot be read; instead, the offsets are recalculated from the trajectory (Issue [#1893][])
 - Masses and charges in **HooMD XML** files are now correctly read ([#2888][])


### PR DESCRIPTION
- CHANGELOG entry was wrong for PDBWriter chain writing: we now correctly write the LAST character of the segid as chainid
- https://github.com/MDAnalysis/mdanalysis/pull/2478#issuecomment-832824399