### PR TITLE
style update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,7 +50,7 @@ feed:
   path: atom.xml
 
 # Custom vars
-version:          1.1.1
+version:          2.0.0
 
 # see also https://help.github.com/articles/repository-metadata-on-github-pages/
 # for what GitHub makes available in site.github

--- a/public/css/hyde.css
+++ b/public/css/hyde.css
@@ -252,11 +252,13 @@ a.sidebar-nav-item:focus {
 /* MDAnalysis theme */
 /* MDA orange: #FF9200
    MDA gray:   #808080
+   RTD dark gray: #343131      (from User Guide RTD dark gray)
+   RTD light grey: #e6e6e6
    MDA black:  #000000
    MDA white:  #FFFFFF
  */
 .theme-base-MDAnalysis .sidebar {
-  background-color: #808080;
+  background-color: #343131;
 }
 .theme-base-MDAnalysis .content a,
 .theme-base-MDAnalysis .related-posts li a:hover {

--- a/sitemapindex.xml
+++ b/sitemapindex.xml
@@ -6,10 +6,10 @@ xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <loc>https://www.mdanalysis.org/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://docs.mdanalysis.org/1.0.0/sitemap.xml</loc>
+    <loc>https://docs.mdanalysis.org/2.0.0/sitemap.xml</loc>
   </sitemap>
   <sitemap>
-    <loc>https://userguide.mdanalysis.org/1.0.0/sitemap.xml</loc>
+    <loc>https://userguide.mdanalysis.org/2.0.0/sitemap.xml</loc>
   </sitemap>
   <sitemap>
     <loc>https://www.mdanalysis.org/pmda/sitemap.xml</loc>


### PR DESCRIPTION
- change sidebar to RTD dark gray (match user guide and docs, see #135)
- update version information to 2.0.0 (in particular make sitemap point to the 2.0.0 docs!!)
![mda-dark-sidebar](https://user-images.githubusercontent.com/237980/131923980-787c789e-800f-4709-9b89-38298e5806c0.png)
