### PR TITLE
Add distopia to sitemap

### DIFF
--- a/sitemapindex.xml
+++ b/sitemapindex.xml
@@ -25,5 +25,8 @@ xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   </sitemap>
   <sitemap>
     <loc>https://www.mdanalysis.org/pytng/sitemap.xml</loc>
-  </sitemap>    
+  </sitemap> 
+  <sitemap>
+    <loc>https://www.mdanalysis.org/distopia/sitemap.xml   
+  </sitemap> 
 </sitemapindex> 


### PR DESCRIPTION
fixes #200 
related to #199 

I have added the distopia sitemap to the master sitemap, however like `PyTNG` it doesn't seem to appear on a search.
@orbeckst any ideas?
