### PR TITLE
Fixed broken link

### DIFF
--- a/_posts/2021-12-01-mdacli.md
+++ b/_posts/2021-12-01-mdacli.md
@@ -122,4 +122,4 @@ and developers to write their analysis using the
 [documentation]: https://mdacli.mdanalysis.org
 [github]: https://github.com/MDAnalysis/mdacli
 [mda_analysis]: https://docs.mdanalysis.org/stable/documentation_pages/analysis/base.html
-[philosophy]: https://mdacli.mdanalysis.org/en/latest/philosophy.html
+[philosophy]: https://mdacli.mdanalysis.org/stable/philosophy.html


### PR DESCRIPTION
During the process of deploying the docs on the webpage, I forgot to fix one link to the mdacli docs. Sorry! 😳