### PR TITLE
re-instated Micaela Matta as Core Dev

### DIFF
--- a/about.md
+++ b/about.md
@@ -72,6 +72,7 @@ team ("MDAnalysis Core Developers") consists of:
 - @IAlibay
 - @jbarnoud
 - @lilyminium
+- @micaela-matta
 - @orbeckst
 - @PicoCentauri
 - @richardjgowers
@@ -94,7 +95,6 @@ The current *Emeriti Core Developers* are:
 - Elizabeth Denning
 - @jandom
 - @kain88-de
-- @micaela-matta
 - @mnmelo
 - @mtiberti
 - @nmichaud


### PR DESCRIPTION
@micaela-matta informed the current Core Devs that she returns to Core Dev status from Emeritus Core Dev.
In line with our governance rules she is herewith reinstated to Core Developer.