### PR TITLE
update governance: PIs must be CoreDevs

### DIFF
--- a/about.md
+++ b/about.md
@@ -59,6 +59,9 @@ The **Core Developers** lead the MDAnalysis project and are responsible to
 the community and to NumFOCUS, our fiscal sponsor. They **represent
 the project publicly** and **vote to make decisions for the project**.
 
+PIs on a grant submitted by MDAnalysis via NumFOCUS must be Core Developers
+while co-PIs do not have to be Core Developers.
+
 Core Developers are granted commit rights (write access) to the [GitHub source
 code repositories][orgrepo] and thus can approve pull requests for merges.
 


### PR DESCRIPTION
As decided by vote and ratified at business meeting on 2023-12-08: "CoreDev status required to be PI on an MDAnalysis grant; co-PIs do not have to be CoreDev."