### PR TITLE
Add feedback form

### DIFF
--- a/about.md
+++ b/about.md
@@ -192,7 +192,7 @@ grateful for Google's support.
 
 ## Feedback
 
-MDAnalysis welcomes feedback from its users and community to help improve. If you have any general feedback or comments to make about the MDAnalysis, the community, events, or other aspects, please [let us know at this anonymous form here](https://docs.google.com/forms/d/e/1FAIpQLScAjjI730i63LbyVkk_tuZ1-FCXUkg6xFugw_gmcsqUvBUtnw/viewform?usp=sf_link)!
+MDAnalysis welcomes feedback from its users and community to help improve. If you have any general feedback or comments to make about the MDAnalysis, the community, events, or other aspects, please [let us know at this anonymous form here](https://forms.gle/n8GLe2QsL2hW2QiDA)!
 
 ------
 

--- a/about.md
+++ b/about.md
@@ -192,7 +192,7 @@ grateful for Google's support.
 
 ## Feedback
 
-MDAnalysis welcomes feedback from its users and community to help improve. If you have any general feedback or comments to make about the MDAnalysis, the community, events, or other aspects, please [let us know at this anonymous form here](https://forms.gle/n8GLe2QsL2hW2QiDA)!
+MDAnalysis welcomes feedback from its users and community to help improve. If you have any general feedback or comments to make about the MDAnalysis, the community, events, or other aspects, please [let us know at this form here](https://forms.gle/n8GLe2QsL2hW2QiDA)!
 
 ------
 

--- a/about.md
+++ b/about.md
@@ -190,6 +190,10 @@ grateful for Google's support.
 
 <div style="clear: both"></div>
 
+## Feedback
+
+MDAnalysis welcomes feedback from its users and community to help improve. If you have any general feedback or comments to make about the MDAnalysis, the community, events, or other aspects, please [let us know at this anonymous form here](https://docs.google.com/forms/d/e/1FAIpQLScAjjI730i63LbyVkk_tuZ1-FCXUkg6xFugw_gmcsqUvBUtnw/viewform?usp=sf_link)!
+
 ------
 
 


### PR DESCRIPTION
As agreed on in the last core-devs meeting, I made a very generic feedback form and added it to the "About" page on the site. We could possibly also make it a separate page so it appears on the sidebar -- right now it's a little buried.

The form is linked as is -- it's very open-ended and generic, and totally anonymous. Not sure if we want to collect emails to have *some* accountability and for some means of following-up?