### PR TITLE
Draft GSoC announcement blog post

### DIFF
--- a/_posts/2024-02-21-gsoc2024.md
+++ b/_posts/2024-02-21-gsoc2024.md
@@ -96,7 +96,7 @@ on during the summer, what you have already done with MDAnalysis (if applicable)
 
 ### Submit a pre-proposal
 
-Selected GSoC contributors with MDAnalysis will need to demonstrate that they have been seriously engaged with the MDAnalysis project by merging a pull request *prior* to submitting their full Application on the [GSoC website][gsoc]. As we know this process can be time consuming for potential contributors and mentors, **we require GSoC applicants to submit a pre-proposal** that will determine who is then invited to attempt a pull request. If you are invited to attempt a pull request and ultimately submit a full application, the pre-proposal will help you gather some of the information you will need to include. Submit your pre-proposal via [this submission form](ADD GOOGLE FORM LINK HERE) by **March 15, 2024**. You should prepare the following information for your pre-proposal:
+Selected GSoC contributors with MDAnalysis will need to demonstrate that they have been seriously engaged with the MDAnalysis project by merging a pull request *prior* to submitting their full Application on the [GSoC website][gsoc]. As we know this process can be time consuming for potential contributors and mentors, **we require GSoC applicants to submit a pre-proposal** that will determine who is then invited to attempt a pull request. If you are invited to attempt a pull request and ultimately submit a full application, the pre-proposal will help you gather some of the information you will need to include. Submit your pre-proposal via [this submission form](ADD GOOGLE FORM LINK HERE) **as soon as possible, but no later than March 15, 2024**. You should prepare the following information for your pre-proposal:
 * GitHub handle
 * Email Address
 * Real Name (optional)
@@ -111,7 +111,9 @@ Selected GSoC contributors with MDAnalysis will need to demonstrate that they ha
 ### Close an issue of MDAnalysis, *if you are invited to based on your pre-proposal*
 
 You must have *at least one commit in the development branch of MDAnalysis* in
-order to be eligible.  We have a list of [easy bugs][] and
+order to be eligible. Note that the earlier you submit your pre-proposal (which are reviewed on a rolling basis), the more time you may have to work on closing an issue!   
+
+We have a list of [easy bugs][] and
 suggested [GSOC Starter issues][GSOC Starter] to work on in our issue tracker
 on GitHub. *We only accept one [GSOC Starter issue][GSOC Starter] per
 applicant* so that all contributors invited to attempt pull requests get a chance. If you want to dive deeper, we

--- a/_posts/2024-02-21-gsoc2024.md
+++ b/_posts/2024-02-21-gsoc2024.md
@@ -1,0 +1,153 @@
+---
+layout: post
+title: Google Summer of Code 2024
+---
+
+<p>
+<img
+src="https://developers.google.com/open-source/gsoc/resources/downloads/GSoC-Vertical.svg"
+title="Google Summer of Code 2023" alt="Google Summer of Code with
+MDAnalysis 2023"
+style="float: right; height: 10em; " />
+</p>
+
+MDAnalysis has been accepted as an [organization][org] for [Google Summer of
+Code 2024][gsoc]! If you are interested in working with us this summer and you
+are new to open source, please read the advice and links below and write to us
+on the [GSoC with MDAnalysis discussion forum][discussion forum].
+
+We are looking forward to all applications from *any new and beginner
+open source contributors over 18 years old* or *students*. Projects
+are scoped as either 90-hour (small), 175-hour (medium) or 350-hour (large) size. The
+duration can be extended from the standard 8 weeks to up to 12 weeks (for small projects), or from the standard 12 weeks up to 22 weeks (for medium or large projects).
+
+The application window **deadline** is **April 2, 2024 - 18:00 UTC**.
+As part of the application process you must familiarize
+yourself with [Google Summer of Code 2024][gsoc].
+
+If you are interested in working with us please read on and contact us
+on our [GSoC with MDAnalysis discussion forum][discussion forum]. Potential GSoC
+Contributors are expected to familiarize themselves with application
+requirements and mentoring organizations as soon as possible. It's
+also never too early to discuss application ideas with us!
+
+## Project Ideas
+
+If you have your own idea about a potential project we'd love to work with you
+to develop this idea; please write to us on the [discussion forum][]
+to discuss it there.
+
+We also have listed several [possible projects][ideas] for you to work on. Our
+initial list of ideas (see summaries in the table below) contains various
+projects of different scope and with different skill requirements. However,
+check the [ideas][] page — we might add more ideas after the posting date of
+this post.
+
+Our experience shows that having the listed skills increases the
+chances that a project will be completed successfully, so we use them
+as part of our decision criteria in choosing GSoC contributors.
+
+
+| project | name                                                                                                                                                      | difficulty | project size | description                                                                                    | skills                      | mentors                                |
+|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|------------|------------|------------------------------------------------------------------------------------------------|-----------------------------|----------------------------------------|
+| 1       | [Generalise Groups]({{ site.github.wiki }}/GSoC-2024-Project-Ideas#project-1-bead-and-ring-groups)                                         | hard     | 350 hours   | Generalise concept of groups                                                                   | Python, NetworkX, Molecular modeling                  | @richardjgowers, @yuxuanzhuang |
+| 2       | [Extend MDAnalysis Interoperability]({{ site.github.wiki }}/GSoC-2024-Project-Ideas#project-2-extend-interoperability)                  | medium     | 350 hours   | Extend converters module to other relevant packages                                            | Python, Molecular modeling                      | @hmacdope, @yuxuanzhuang, @xhgchen |
+| 3       | [On the fly transformations]({{ site.github.wiki }}/GSoC-2024-Project-Ideas#project-3-on-the-fly-transformations)                  | medium/hard     | 175/350 hours   |  Expand on code for on-the-fly transformations through documentation, product research or performance optimization | Python, Molecular modeling, Computational chemistry, Scientific writing, Performance profiling                      | @richardjgowers, @cbouy, @hmacdope, @xhgchen |
+| 4       | [2D visualization for small molecules]({{ site.github.wiki }}/GSoC-2024-Project-Ideas#project-4-2d-visualization-for-small-molecules)                                         | easy     | 90 hours  | Add basic 2D visualization functionalities for small molecule groups in notebooks                                                                   | Python, basic knowledge of MDAnalysis and RDKit                 | @cbouy, @hmacdope, @xhgchen |
+| 5       | [Better interfacing of Blender and MDAnalysis]({{ site.github.wiki }}/GSoC-2024-Project-Ideas#project-5-better-interfacing-of-blender-and-mdanalysis)                                         | medium     | 350 hours   | Add functionality to visualize simple MDAnalysis results in Blender                                                                  | Python, basic knowledge of MDAnalysis, familiarity with Blender ideal                  | @BradyAJohnston, @yuxuanzhuang |
+
+
+## Information for prospective GSoC Contributors
+
+You must meet our [own requirements] if you want to be a GSoC
+Contributor with MDAnalysis this year (read all the docs behind these
+links!). You must also meet the [eligibility criteria]. Our [GSoC
+FAQ][] collects common questions from applicants.
+
+The MDAnalysis community values diversity and is committed to providing a
+productive, harassment-free environment to every member. Our [Code of Conduct]
+explains the values that we as a community uphold. *Every member (and every
+GSoC Contributor) agrees to follow the [Code of Conduct]*.
+
+As a start to get familiar with MDAnalysis and open source development you
+should follow these steps:
+
+### Watch the MDAnalysis Trailer
+
+The [MDAnalysis Trailer](https://www.youtube.com/watch?v=uMAfvwFkD3o) on YouTube
+is a one minute introduction to MDAnalysis.
+
+<div class="js-video">
+	<iframe src="https://www.youtube.com/embed/uMAfvwFkD3o" frameborder="0"
+	allowfullscreen class="video"></iframe>
+</div>
+
+
+### Complete the Quick Start Guide
+
+Start by [installing] the MDAnalysis package. We have a [Quick Start Guide] explaining the basics of MDAnalysis. You
+should go through it at least once to understand how MDAnalysis is
+used. Continue reading the [User Guide] to learn more.
+
+### Introduce yourself to us
+
+Introduce yourself on the [discussion forum]. Tell us your GitHub handle, what you plan to work
+on during the summer, what you have already done with MDAnalysis (if applicable), and your experience with molecular dynamics or computational physics/chemistry/materials.
+
+### Submit a pre-proposal
+
+Selected GSoC contributors with MDAnalysis will need to demonstrate that they have been seriously engaged with the MDAnalysis project by merging a pull request *prior* to submitting their full Application on the [GSoC website][gsoc]. As we know this process can be time consuming for potential contributors and mentors, **we require GSoC applicants to submit a pre-proposal** that will determine who is then invited to attempt a pull request. If you are invited to attempt a pull request and ultimately submit a full application, the pre-proposal will help you gather some of the information you will need to include. Submit your pre-proposal via [this submission form](ADD GOOGLE FORM LINK HERE) by **March 15, 2024**. You should prepare the following information for your pre-proposal:
+* GitHub handle
+* Email Address
+* Real Name (optional)
+* Basic Information on Your Background (e.g., Education, Relevant Experience)
+* Project Title
+* Project Size (90h, 175h, 350h)
+* **Problem:** Describe the problem to be solved. What is the background? What is the overarching question? You can also comment on why this is an interesting or difficult problem. Clearly define the overall goal of what you want to find out.
+* **Approach:** Describe how you are going to reach your goal (i.e., answer the overarching question). Which algorithms are you going to use? Are there any libraries or other packages you want to use? Do you need to research different solutions? Be as concrete as possible; you want to convince your audience that it is feasible to solve this problem and you have an idea how to tackle it.
+* **Objectives:** Use a numbered list to state 3–5 measurable non-trivial outcomes that you need to achieve in order to reach the overall goal. These are the milestones that you have to reach; they are possibly dependent on each other. For each objective it must be clear how to decide if you fulfilled it or not. Objectives are formulated in terms of actions and deliverables.
+
+
+### Close an issue of MDAnalysis, *if you are invited to based on your pre-proposal*
+
+You must have *at least one commit in the development branch of MDAnalysis* in
+order to be eligible.  We have a list of [easy bugs][] and
+suggested [GSOC Starter issues][GSOC Starter] to work on in our issue tracker
+on GitHub. *We only accept one [GSOC Starter issue][GSOC Starter] per
+applicant* so that all contributors invited to attempt pull requests get a chance. If you want to dive deeper, we
+encourage you to tackle some of the other issues in our issue tracker. We also appreciate contributions which add more tests or update/improve our documentation.
+
+To start developing for MDAnalysis have a look at our guide on
+[contributing to MDAnalysis][dev-guide] and write to us on the [GSoC with MDAnalysis discussion forum][discussion forum] if you have more questions
+about setting up a development environment or how to contribute.
+
+## Final remarks
+
+Introduce yourself and **submit your pre-proposal before March 15, 2024**, but the earlier the better! We will then let you know if you have been selected to attempt an issue on GitHub and ultimately submit a full application. The GSoC contributor application period opens on March 18, 2024.
+
+Feel free to ask any questions on the [discussion forum]. We are also happy to chat on our [{{ site.discord.name }} Discord
+server][discord] in the `#gsoc` channel (join with the public
+[invitation link]({{ site.baseurl }}/#participating)).
+
+We look forward to working with you in GSoC 2024!
+
+
+— MDAnalysis GSoC mentors (GitHub [@MDAnalysis/gsoc-mentors], Discord `@gsoc-mentor`)
+
+
+[org]: https://summerofcode.withgoogle.com/programs/2024/organizations/mdanalysis
+[Code of Conduct]: {{ site.baseurl }}/pages/conduct/
+[eligibility criteria]: https://developers.google.com/open-source/gsoc/faq#what_are_the_eligibility_requirements_for_participation
+[own requirements]: {{ site.github.wiki }}/Google-Summer-Of-Code#our-expectations-from-gsoc-contributors
+[easy bugs]: https://github.com/MDAnalysis/mdanalysis/issues?q=is%3Aopen+is%3Aissue+label%3ADifficulty-easy
+[GSOC Starter]: https://github.com/MDAnalysis/mdanalysis/issues?q=is%3Aopen+is%3Aissue+label%3A%22GSOC+Starter%22
+[installing]: https://userguide.mdanalysis.org/stable/installation.html
+[Quick Start Guide]: https://userguide.mdanalysis.org/stable/examples/quickstart.html
+[User Guide]: https://userguide.mdanalysis.org/
+[ideas]: {{ site.github.wiki }}/GSoC-2024-Project-Ideas
+[gsoc]: https://summerofcode.withgoogle.com/
+[dev-guide]: https://userguide.mdanalysis.org/stable/contributing.html
+[discussion forum]: {{ site.mailinglists.gsoc.url }}
+[GSoC FAQ]: {{ site.github.wiki }}/GSoC-FAQ
+[@MDAnalysis/gsoc-mentors]: https://github.com/orgs/MDAnalysis/teams/gsoc-mentors
+[discord]: {{ site.discord.url }}


### PR DESCRIPTION
I am uploading a draft GSoC blog post to spark discussion around finalizing our contributor application process. I have included @orbeckst's [suggestions from Discord](https://discord.com/channels/807348386012987462/809458436395761674/1209579508760580137) for the pre-proposal as a starting point. If there is agreement around this, I will make a Google form and add in the link.

I would suggest a rolling deadline to encourage applicants to submit a pre-proposal early, with a hard deadline on March 15 (since the full application window for GSoC opens Mar 18). 

Once all of this is decided, we will need to also add this information to the [GSoC wiki page](https://github.com/MDAnalysis/mdanalysis/wiki/Google-Summer-Of-Code) and [FAQ](https://github.com/MDAnalysis/mdanalysis/wiki/GSoC-FAQ).

Can all @MDAnalysis/gsoc-mentors and admins (@yuxuanzhuang, @xhgchen, @cbouy, @BradyAJohnston, @richardjgowers, @hmacdope, @IAlibay) please review as soon as you can? Thanks!