### PR TITLE
add mission statement to About

### DIFF
--- a/about.md
+++ b/about.md
@@ -9,13 +9,13 @@ style="float: right" alt="MDAnalysis" width="30%"/>
 ## Mission
 
 The MDAnalysis [Community](#community) is interested in all facets of **working
-with data in the molecular sciences**. We welcome everyone. **We all follow our
+with data in the computational molecular sciences**. We welcome everyone. **We all follow our
 [Code of Conduct] and strive to create an environment that is welcoming to
 all.** Our primary purpose is to produce software that scientists in academia and
 industry will trust to use in their research.
 
 We develop and maintain projects related to the broader goal of processing and
-analyzing data in the molecular sciences. We aim to empower users/developers to
+analyzing data in the computational molecular sciences. We aim to empower users/developers to
 work with our packages following [FAIR principles]. Our central package is the
 [MDAnalysis library] for the analysis of computer simulations of many-body
 systems at the molecular scale. 

--- a/about.md
+++ b/about.md
@@ -6,7 +6,7 @@ title: About MDAnalysis
 <img src="{{ site.baseurl }}/public/mdanalysis-logo_square.png"
 style="float: right" alt="MDAnalysis" width="30%"/>
 
-## About the MDAnalysis Project
+## Mission
 
 The MDAnalysis [Community](#community) is interested in all facets of **working
 with data in the molecular sciences**. We welcome everyone. **We all follow our

--- a/about.md
+++ b/about.md
@@ -6,6 +6,26 @@ title: About MDAnalysis
 <img src="{{ site.baseurl }}/public/mdanalysis-logo_square.png"
 style="float: right" alt="MDAnalysis" width="30%"/>
 
+## About the MDAnalysis Project
+
+The MDAnalysis [Community](#community) is interested in all facets of **working
+with data in the molecular sciences**. We welcome everyone. **We all follow our
+[Code of Conduct] and strive to create an environment that is welcoming to
+all.** Our primary purpose is to produce software that scientists in academia and
+industry will trust to use in their research.
+
+We develop and maintain projects related to the broader goal of processing and
+analyzing data in the molecular sciences. We aim to empower users/developers to
+work with our packages following [FAIR principles]. Our central package is the
+[MDAnalysis library] for the analysis of computer simulations of many-body
+systems at the molecular scale. 
+
+We believe that scientific software should be open to all while using best
+practices to maintain high standards of correctness and reproducibility. We
+emphasize educating our users to make best use of the tools that we produce, to
+enable them to become contributors to our community and code bases.
+
+
 
 ## Community
 
@@ -263,7 +283,9 @@ MDAnalysis welcomes feedback for improvement from its users and community. If yo
 
 ------
 
-
+[Code of Conduct]: {{ site.baseurl }}/pages/conduct/
+[MDAnalysis library]: {{ site.github.repo }}
+[FAIR principles]: https://www.go-fair.org/fair-principles/
 [NumFOCUS]: https://www.numfocus.org
 [simple majority]: https://en.wikipedia.org/wiki/Majority#Majority_vote
 [orgrepo]: https://github.com/MDAnalysis


### PR DESCRIPTION
Closes #363 

This PR
- adds a mission statement under **About the MDAnalysis Project** to the top of the [About](https://www.mdanalysis.org/about/) page ("version 1" draft, as agreed at Business Meeting on 2024-02-26)
- asks @MDAnalysis/coredevs to review and alter the language as needed
- invites anyone interested in the direction that MDAnalysis takes to comment
- asks @MDAnalysis/coredevs to ultimately approve the final mission statement

This Mission Statement is not set in stone and should be periodically revisited and updated. However, it seems unlikely that such updates will happen frequently so you should consider this language to have a long half-life (i.e., it will guide decisions for years to come).