### PR TITLE
Add jennaswa and yuxuanzhuang to Core Devs list on about page

### DIFF
--- a/about.md
+++ b/about.md
@@ -69,15 +69,16 @@ The current
 [@MDAnalysis/coredevs](https://github.com/orgs/MDAnalysis/teams/coredevs/members)
 team ("MDAnalysis Core Developers") consists of:
 
-
 - @fiona-naughton
 - @hmacdope
+- @jennaswa
 - @lilyminium
 - @micaela-matta
 - @orbeckst
 - @richardjgowers
 - @RMeli
 - @tylerjereddy
+- @yuxuanzhuang
 
 ### MDAnalysis Emeriti Core Developers
 


### PR DESCRIPTION
In combination with previous PRs, closes https://github.com/MDAnalysis/MDAnalysis.github.io/issues/300.

In this PR, 2 additional people are listed as [MDAnalysis Core Developers](https://www.mdanalysis.org/about/#mdanalysis-core-developers) on the website's **About** page:

- jennaswa (core dev privileges granted to PCM as decided by a vote at 2024-12-18 business meeting)
- yuxuanzhuang (elected by a vote at 2024-02-26 business meeting; accepted invitation 2024-03-02) 