### PR TITLE
Sorted sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,20 @@ not be touched, as this is only here to set the paginator.
 We are using the minimalist [Hyde](https://github.com/poole/hyde) theme for
 [Jekyll](https://jekyllrb.com/docs/).
 
+### Static pages
 Additional static pages go under `pages`. If they have the layout type
-"page" they will be automatically included in the sidebar. The static
+"page" they will be automatically included in the *sidebar*. The static
 "about" page is left at the top level.
+
+To customize the *order of pages in the sidebar*, add the attribute
+`order: <INTEGER>` to the front-matter. Pages will be sorted lowest to
+highest. Note that some entries in the sidebar are hardcoded in
+`_includes/sidebar.html`.
+
+If a page should *not show up in the sidebar*, use `layout:
+otherpage`.
+
+
 
 
 ### Creating content ###

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -22,7 +22,7 @@
 
       {% assign blogpagedir = site.paginate_path | split: ":" | first %}
       {% assign blogpagedir_len = blogpagedir | size %}
-      {% assign pages_list = site.pages %}
+      {% assign pages_list = site.pages | sort: "order" %}
       {% for node in pages_list %}
         {% if node.title != null %}
           {% if node.layout == "page" %}

--- a/pages/basic_example.md
+++ b/pages/basic_example.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Basic example
+order: 1
 ---
 
 A typical usage pattern is to iterate through a trajectory and analyze

--- a/pages/citations.md
+++ b/pages/citations.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Citations
+order: 100
 ---
 
 MDAnalysis and the included algorithms are scientific software that

--- a/pages/conduct.md
+++ b/pages/conduct.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Code of Conduct
+order: 0
 ---
 
 <!-- DON'T CHANGE THIS. ALWAYS COPY FROM THE MAIN CODE REPOSITORY -->

--- a/pages/installation_quick_start.md
+++ b/pages/installation_quick_start.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Installation Quick Start
+order: 2
 ---
 
 MDAnalysis offers two methods to install the released version. For most

--- a/pages/learning_MDAnalysis.md
+++ b/pages/learning_MDAnalysis.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Learning MDAnalysis
+order: 3
 ---
 
 Once you had a look at the 

--- a/pages/mdakits.md
+++ b/pages/mdakits.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: MDAKits and MDA-based tools
+order: 5
 ---
 
 MDAnalysis is developed with extensibility in mind, allowing

--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Privacy Policy
+order: 10
 ---
 
 MDAnalysis is a [fiscally sponsored

--- a/pages/team.md
+++ b/pages/team.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: MDAnalysis team
+order: 4
 ---
 
 MDAnalysis is a community-driven project that is made possible through the efforts of many members who contribute in numerous and diverse ways, ranging from direct package development, maintenance, documentation, communication, and managerial responsibilities. On this page we list identified project roles and team members for each of those roles. We note that the listed roles on this page can differ significantly in scope and required effort.

--- a/pages/ugm2023.md
+++ b/pages/ugm2023.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: otherpage
 title: UGM 2023
 ---
 

--- a/pages/ugm2024.md
+++ b/pages/ugm2024.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: UGM 2024
+order: 5
 ---
 
 ## When and Where


### PR DESCRIPTION
- fix #371 
- add `order: N` attribute to front-matter of `layout: page` pages to have them sorted by order
- update README with instructions
- preliminary ordering (please change!)
- removed UGM 2023 from sidebar