### PR TITLE
Fix workshop post

### DIFF
--- a/_posts/2024-04-24-ASUworkshop.md
+++ b/_posts/2024-04-24-ASUworkshop.md
@@ -1,17 +1,17 @@
 ---
 layout: post
-title: Save the Date: June 24th-25th, 2024 - in-person workshop at Arizona State University
+title: Save the Date! June 24th-25th, 2024 - in-person workshop at Arizona State University
 ---
 
 <img
 src="/public/images/ASUworkshop_cactus.png"
 title="MDAnalysis ASU workshop 2024" alt="MDAnalysis Workshop June 24-25th, 2024 at Arizona State University"
-style="float: left; height: 20em; " />
+style="float: right; height: 20em; " />
 
 <img
 src="/public/images/MolSSI_Logo.png"
 title="MolSSI logo" alt="MolSSI logo"
-style="float: left; height: 5em; " />
+style="float: right; height: 5em; " />
 
 MDAnalysis, in conjunction with [MolSSI](https://molssi.org/), is happy to announce an 
 upcoming in-person workshop, to be held **June 24th-25th**, 2024 at **Arizona State University** 

--- a/_posts/2024-04-24-ASUworkshop.md
+++ b/_posts/2024-04-24-ASUworkshop.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title: "Save the Date: June 24th-25th, 2024 - in-person workshop at Arizona State University"
+---
 
 <img
 src="/public/images/ASUworkshop_cactus.png"


### PR DESCRIPTION
The title is not showing up properly for the workshop blog post - I suspect having a colon in the title upset it; replaced that. Also adjusting the image alignment while I'm here.