### PR TITLE
Draft blog post to advertise Richard's CCPBioSim talk

### DIFF
--- a/_posts/2024-05-30-ccpbiosim-industry-talk.md
+++ b/_posts/2024-05-30-ccpbiosim-industry-talk.md
@@ -8,7 +8,7 @@ src="/public/images/CCPBioSim_Logo.jpeg"
 title="CCPBioSim Logo" alt="CCPBioSim Logo"
 style="float: right; height: 5em; " />
 
-MDAnalysis has partnered with [CCPBioSim](https://www.ccpbiosim.ac.uk/) to offer an industry talk on **June 19, 2024** from **14:00 - 15:30 BST**, presented by MDAnalysis core developer, @richardgowers.
+MDAnalysis has partnered with [CCPBioSim](https://www.ccpbiosim.ac.uk/) to offer an industry talk on **June 19, 2024** from **14:00 - 15:30 BST**, presented by MDAnalysis core developer Richard Gowers (@richardgowers).
 
 **Title:** MDAnalysis and Alchemical Simulations
 

--- a/_posts/2024-05-30-ccpbiosim-industry-talk.md
+++ b/_posts/2024-05-30-ccpbiosim-industry-talk.md
@@ -8,7 +8,7 @@ src="/public/images/CCPBioSim_Logo.jpeg"
 title="CCPBioSim Logo" alt="CCPBioSim Logo"
 style="float: right; height: 5em; " />
 
-MDAnalysis has partnered with [CCPBioSim](https://www.ccpbiosim.ac.uk/) to offer an industry talk on **June 19, 2024** from **14:00 - 15:30 BST**, presented by MDAnalysis core developer Richard Gowers (@richardgowers).
+MDAnalysis has partnered with [CCPBioSim](https://www.ccpbiosim.ac.uk/) to offer an industry talk on **June 19, 2024** from **14:00 - 15:30 BST**, presented by MDAnalysis core developer, Richard Gowers (@richardjgowers).
 
 **Title:** MDAnalysis and Alchemical Simulations
 

--- a/_posts/2024-05-30-ccpbiosim-industry-talk.md
+++ b/_posts/2024-05-30-ccpbiosim-industry-talk.md
@@ -1,0 +1,16 @@
+---
+layout: post
+title: CCPBioSim Industry Talk by Richard Gowers (MDAnalysis Core Developer)
+---
+
+<img
+src="/public/images/CCPBioSim_Logo.jpeg"
+title="CCPBioSim Logo" alt="CCPBioSim Logo"
+style="float: right; height: 5em; " />
+
+MDAnalysis has partnered with [CCPBioSim](https://www.ccpbiosim.ac.uk/) to offer an industry talk on **June 19, 2024** from **14:00 - 15:30 BST**, presented by MDAnalysis core developer, @richardgowers.
+
+**Title:** MDAnalysis and Alchemical Simulations
+**Abstract:** MDAnalysis is a popular Python package for the analysis of molecular dynamics simulation data. After introducing the package in broad strokes, this talk will give insight into how this package has been used and extended to process data coming from so-called “alchemical simulations”; where molecules are perturbed through non-physical states to provide estimates of properties such as binding affinities. Topics included will be biopolymer recognition, handling of multistate simulation data and analysing hybrid topology alchemical models.
+
+Although attendance is free, you must register to receive the relevant Zoom information. Check out the [CCPBioSim event page](https://www.ccpbiosim.ac.uk/events/upcoming-events/eventdetail/122/-/industry-talk-mdanalysis) to access the registration link and find out more information.

--- a/_posts/2024-05-30-ccpbiosim-industry-talk.md
+++ b/_posts/2024-05-30-ccpbiosim-industry-talk.md
@@ -11,6 +11,7 @@ style="float: right; height: 5em; " />
 MDAnalysis has partnered with [CCPBioSim](https://www.ccpbiosim.ac.uk/) to offer an industry talk on **June 19, 2024** from **14:00 - 15:30 BST**, presented by MDAnalysis core developer, @richardgowers.
 
 **Title:** MDAnalysis and Alchemical Simulations
+
 **Abstract:** MDAnalysis is a popular Python package for the analysis of molecular dynamics simulation data. After introducing the package in broad strokes, this talk will give insight into how this package has been used and extended to process data coming from so-called “alchemical simulations”; where molecules are perturbed through non-physical states to provide estimates of properties such as binding affinities. Topics included will be biopolymer recognition, handling of multistate simulation data and analysing hybrid topology alchemical models.
 
 Although attendance is free, you must register to receive the relevant Zoom information. Check out the [CCPBioSim event page](https://www.ccpbiosim.ac.uk/events/upcoming-events/eventdetail/122/-/industry-talk-mdanalysis) to access the registration link and find out more information.


### PR DESCRIPTION
CCPBioSim now has an event page for @richardjgowers's  talk on June 19: https://www.ccpbiosim.ac.uk/events/upcoming-events/eventdetail/122/-/industry-talk-mdanalysis.

It'd be great to get a blog post out so that we can spread the news on our socials and encourage people to register.