### PR TITLE
Update contact information for Team page

### DIFF
--- a/_data/team/roles/code_of_conduct.yml
+++ b/_data/team/roles/code_of_conduct.yml
@@ -11,3 +11,4 @@ current_members:
   - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
   - "[Richard Gowers](https://github.com/richardjgowers)"
   - "[Micaela Matta](https://github.com/micaela-matta)"
+  - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"

--- a/_data/team/roles/code_of_conduct.yml
+++ b/_data/team/roles/code_of_conduct.yml
@@ -8,6 +8,6 @@ tasks:
   - Periodically review, revise and update current code of conduct procedures
 
 current_members:
-  - [Jenna Swarthout Goddard](https://github.com/jennaswa)
-  - [Richard Gowers](https://github.com/richardjgowers)
-  - [Micaela Matta](https://github.com/micaela-matta)
+  - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
+  - "[Richard Gowers](https://github.com/richardjgowers)"
+  - "[Micaela Matta](https://github.com/micaela-matta)"

--- a/_data/team/roles/code_of_conduct.yml
+++ b/_data/team/roles/code_of_conduct.yml
@@ -9,6 +9,5 @@ tasks:
 
 current_members:
   - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
-  - "[Richard Gowers](https://github.com/richardjgowers)"
   - "[Micaela Matta](https://github.com/micaela-matta)"
   - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"

--- a/_data/team/roles/community_engagement.yml
+++ b/_data/team/roles/community_engagement.yml
@@ -6,3 +6,5 @@ tasks:
 current_members:
   - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
   - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"
+  - "[Rocco Meli](https://github.com/RMeli)"
+  - "[Oliver Beckstein](https://github.com/orbeckst)"

--- a/_data/team/roles/community_engagement.yml
+++ b/_data/team/roles/community_engagement.yml
@@ -4,6 +4,7 @@ tasks:
   - Managing and triaging conversations on Discord and GitHub Discussions
 
 current_members:
+  - "[Brady Johnston](https://github.com/bradyajohnston)"
   - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
   - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"
   - "[Rocco Meli](https://github.com/RMeli)"

--- a/_data/team/roles/community_engagement.yml
+++ b/_data/team/roles/community_engagement.yml
@@ -5,3 +5,4 @@ tasks:
 
 current_members:
   - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
+  - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"

--- a/_data/team/roles/community_engagement.yml
+++ b/_data/team/roles/community_engagement.yml
@@ -4,4 +4,4 @@ tasks:
   - Managing and triaging conversations on Discord and GitHub Discussions
 
 current_members:
-  - [Jenna Swarthout Goddard](https://github.com/jennaswa)
+  - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"

--- a/_data/team/roles/continuous_integration.yml
+++ b/_data/team/roles/continuous_integration.yml
@@ -8,3 +8,4 @@ current_members:
   - "[Fiona Naughton](https://github.com/fiona-naughton)"
   - "[Irfan Alibay](https://github.com/IAlibay)"
   - "[Richard Gowers](https://github.com/richardjgowers)"
+  - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"

--- a/_data/team/roles/continuous_integration.yml
+++ b/_data/team/roles/continuous_integration.yml
@@ -5,6 +5,6 @@ tasks:
   - Maintenance and fixes
 
 current_members:
-  - Fiona Naughton
-  - Irfan Alibay
-  - Richard Gowers
+  - Fiona Naughton (https://github.com/fiona-naughton)
+  - Irfan Alibay (https://github.com/IAlibay)
+  - Richard Gowers (https://github.com/richardjgowers)

--- a/_data/team/roles/continuous_integration.yml
+++ b/_data/team/roles/continuous_integration.yml
@@ -7,5 +7,6 @@ tasks:
 current_members:
   - "[Fiona Naughton](https://github.com/fiona-naughton)"
   - "[Irfan Alibay](https://github.com/IAlibay)"
+  - "[Paul Smith](https://github.com/p-j-smith)"
   - "[Richard Gowers](https://github.com/richardjgowers)"
   - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"

--- a/_data/team/roles/continuous_integration.yml
+++ b/_data/team/roles/continuous_integration.yml
@@ -5,6 +5,6 @@ tasks:
   - Maintenance and fixes
 
 current_members:
-  - [Fiona Naughton](https://github.com/fiona-naughton)
-  - [Irfan Alibay](https://github.com/IAlibay)
-  - [Richard Gowers](https://github.com/richardjgowers)
+  - "[Fiona Naughton](https://github.com/fiona-naughton)"
+  - "[Irfan Alibay](https://github.com/IAlibay)"
+  - "[Richard Gowers](https://github.com/richardjgowers)"

--- a/_data/team/roles/continuous_integration.yml
+++ b/_data/team/roles/continuous_integration.yml
@@ -5,6 +5,6 @@ tasks:
   - Maintenance and fixes
 
 current_members:
-  - Fiona Naughton (https://github.com/fiona-naughton)
-  - Irfan Alibay (https://github.com/IAlibay)
-  - Richard Gowers (https://github.com/richardjgowers)
+  - [Fiona Naughton](https://github.com/fiona-naughton)
+  - [Irfan Alibay](https://github.com/IAlibay)
+  - [Richard Gowers](https://github.com/richardjgowers)

--- a/_data/team/roles/core_library_maintenance.yml
+++ b/_data/team/roles/core_library_maintenance.yml
@@ -30,4 +30,4 @@ subroles:
       - Emergency fixes
       - Other general maintenance tasks
     current_members:
-      - [Irfan Alibay](https://github.com/IAlibay)
+      - "[Irfan Alibay](https://github.com/IAlibay)"

--- a/_data/team/roles/core_library_maintenance.yml
+++ b/_data/team/roles/core_library_maintenance.yml
@@ -9,17 +9,17 @@ subroles:
       - Initial triage and tagging of issues
       - Managing timely responses and resolving issues
     current_members:
-      - Rocco Meli (https://github.com/RMeli)
-      - Hugo MacDermott-Opeskin (https://github.com/hmacdope)
+      - [Rocco Meli](https://github.com/RMeli)
+      - [Hugo MacDermott-Opeskin](https://github.com/hmacdope)
     
 
   - subrole: Pull request management
     tasks:
       - Reviewing, shepherding, and merging pull requests
     current_members:
-      - Oliver Beckstein (https://github.com/orbeckst)
-      - Rocco Meli (https://github.com/RMeli)
-      - Hugo MacDermott-Opeskin (https://github.com/hmacdope)
+      - [Oliver Beckstein](https://github.com/orbeckst)
+      - [Rocco Meli](https://github.com/RMeli)
+      - [Hugo MacDermott-Opeskin](https://github.com/hmacdope)
     
   
   - subrole: General maintenance
@@ -30,4 +30,4 @@ subroles:
       - Emergency fixes
       - Other general maintenance tasks
     current_members:
-      - Irfan Alibay (https://github.com/IAlibay)
+      - [Irfan Alibay](https://github.com/IAlibay)

--- a/_data/team/roles/core_library_maintenance.yml
+++ b/_data/team/roles/core_library_maintenance.yml
@@ -9,17 +9,17 @@ subroles:
       - Initial triage and tagging of issues
       - Managing timely responses and resolving issues
     current_members:
-      - Rocco Meli
-      - Hugo MacDermott-Opeskin
+      - Rocco Meli (https://github.com/RMeli)
+      - Hugo MacDermott-Opeskin (https://github.com/hmacdope)
     
 
   - subrole: Pull request management
     tasks:
       - Reviewing, shepherding, and merging pull requests
     current_members:
-      - Oliver Beckstein
-      - Rocco Meli
-      - Hugo MacDermott-Opeskin
+      - Oliver Beckstein (https://github.com/orbeckst)
+      - Rocco Meli (https://github.com/RMeli)
+      - Hugo MacDermott-Opeskin (https://github.com/hmacdope)
     
   
   - subrole: General maintenance
@@ -30,4 +30,4 @@ subroles:
       - Emergency fixes
       - Other general maintenance tasks
     current_members:
-      - Irfan Alibay
+      - Irfan Alibay (https://github.com/IAlibay)

--- a/_data/team/roles/core_library_maintenance.yml
+++ b/_data/team/roles/core_library_maintenance.yml
@@ -17,9 +17,9 @@ subroles:
     tasks:
       - Reviewing, shepherding, and merging pull requests
     current_members:
-      - [Oliver Beckstein](https://github.com/orbeckst)
-      - [Rocco Meli](https://github.com/RMeli)
-      - [Hugo MacDermott-Opeskin](https://github.com/hmacdope)
+      - "[Oliver Beckstein](https://github.com/orbeckst)"
+      - "[Rocco Meli](https://github.com/RMeli)"
+      - "[Hugo MacDermott-Opeskin](https://github.com/hmacdope)"
     
   
   - subrole: General maintenance

--- a/_data/team/roles/core_library_maintenance.yml
+++ b/_data/team/roles/core_library_maintenance.yml
@@ -10,6 +10,7 @@ subroles:
       - Managing timely responses and resolving issues
     current_members:
       - "[Rocco Meli](https://github.com/RMeli)"
+      - "[Brady Johnston](https://github.com/bradyajohnston)"
       - "[Hugo MacDermott-Opeskin](https://github.com/hmacdope)"
       - "[Paul Smith](https://github.com/p-j-smith)"
 
@@ -34,6 +35,7 @@ subroles:
       - Emergency fixes
       - Other general maintenance tasks
     current_members:
+      - "[Brady Johnston](https://github.com/bradyajohnston)"
       - "[Irfan Alibay](https://github.com/IAlibay)"
       - "[Paul Smith](https://github.com/p-j-smith)"
       - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"

--- a/_data/team/roles/core_library_maintenance.yml
+++ b/_data/team/roles/core_library_maintenance.yml
@@ -11,6 +11,8 @@ subroles:
     current_members:
       - "[Rocco Meli](https://github.com/RMeli)"
       - "[Hugo MacDermott-Opeskin](https://github.com/hmacdope)"
+      - "[Paul Smith](https://github.com/p-j-smith)"
+
     
 
   - subrole: Pull request management
@@ -20,6 +22,8 @@ subroles:
       - "[Oliver Beckstein](https://github.com/orbeckst)"
       - "[Rocco Meli](https://github.com/RMeli)"
       - "[Hugo MacDermott-Opeskin](https://github.com/hmacdope)"
+      - "[Paul Smith](https://github.com/p-j-smith)"
+
     
   
   - subrole: General maintenance
@@ -31,4 +35,5 @@ subroles:
       - Other general maintenance tasks
     current_members:
       - "[Irfan Alibay](https://github.com/IAlibay)"
+      - "[Paul Smith](https://github.com/p-j-smith)"
       - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"

--- a/_data/team/roles/core_library_maintenance.yml
+++ b/_data/team/roles/core_library_maintenance.yml
@@ -9,8 +9,8 @@ subroles:
       - Initial triage and tagging of issues
       - Managing timely responses and resolving issues
     current_members:
-      - [Rocco Meli](https://github.com/RMeli)
-      - [Hugo MacDermott-Opeskin](https://github.com/hmacdope)
+      - "[Rocco Meli](https://github.com/RMeli)"
+      - "[Hugo MacDermott-Opeskin](https://github.com/hmacdope)"
     
 
   - subrole: Pull request management

--- a/_data/team/roles/core_library_maintenance.yml
+++ b/_data/team/roles/core_library_maintenance.yml
@@ -31,3 +31,4 @@ subroles:
       - Other general maintenance tasks
     current_members:
       - "[Irfan Alibay](https://github.com/IAlibay)"
+      - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"

--- a/_data/team/roles/documentation.yml
+++ b/_data/team/roles/documentation.yml
@@ -8,7 +8,7 @@ tasks:
   - Responding to documentation issues in sub-projects
 
 current_members:
-  - Lily Wang
-  - Rocco Meli
+  - Lily Wang (https://github.com/lilyminium)
+  - Rocco Meli (https://github.com/RMeli)
 
 

--- a/_data/team/roles/documentation.yml
+++ b/_data/team/roles/documentation.yml
@@ -8,7 +8,7 @@ tasks:
   - Responding to documentation issues in sub-projects
 
 current_members:
-  - [Lily Wang](https://github.com/lilyminium)
-  - [Rocco Meli](https://github.com/RMeli)
+  - "[Lily Wang](https://github.com/lilyminium)"
+  - "[Rocco Meli](https://github.com/RMeli)"
 
 

--- a/_data/team/roles/documentation.yml
+++ b/_data/team/roles/documentation.yml
@@ -10,5 +10,6 @@ tasks:
 current_members:
   - "[Lily Wang](https://github.com/lilyminium)"
   - "[Rocco Meli](https://github.com/RMeli)"
+  - "[Irfan Alibay](https://github.com/IAlibay)"
 
 

--- a/_data/team/roles/documentation.yml
+++ b/_data/team/roles/documentation.yml
@@ -8,7 +8,7 @@ tasks:
   - Responding to documentation issues in sub-projects
 
 current_members:
-  - Lily Wang (https://github.com/lilyminium)
-  - Rocco Meli (https://github.com/RMeli)
+  - [Lily Wang](https://github.com/lilyminium)
+  - [Rocco Meli](https://github.com/RMeli)
 
 

--- a/_data/team/roles/external_liaison.yml
+++ b/_data/team/roles/external_liaison.yml
@@ -5,6 +5,6 @@ tasks:
   - Coordinate with potential industry partners
 
 current_members:
-  - Irfan Alibay (https://github.com/IAlibay)
-  - Oliver Beckstein (https://github.com/orbeckst)
-  - Jenna Swarthout Goddard (https://github.com/jennaswa)
+  - [Irfan Alibay](https://github.com/IAlibay)
+  - [Oliver Beckstein](https://github.com/orbeckst)
+  - [Jenna Swarthout Goddard](https://github.com/jennaswa)

--- a/_data/team/roles/external_liaison.yml
+++ b/_data/team/roles/external_liaison.yml
@@ -5,6 +5,6 @@ tasks:
   - Coordinate with potential industry partners
 
 current_members:
-  - Irfan Alibay
-  - Oliver Beckstein
-  - Jenna Swarthout Goddard
+  - Irfan Alibay (https://github.com/IAlibay)
+  - Oliver Beckstein (https://github.com/orbeckst)
+  - Jenna Swarthout Goddard (https://github.com/jennaswa)

--- a/_data/team/roles/external_liaison.yml
+++ b/_data/team/roles/external_liaison.yml
@@ -5,6 +5,6 @@ tasks:
   - Coordinate with potential industry partners
 
 current_members:
-  - [Irfan Alibay](https://github.com/IAlibay)
-  - [Oliver Beckstein](https://github.com/orbeckst)
-  - [Jenna Swarthout Goddard](https://github.com/jennaswa)
+  - "[Irfan Alibay](https://github.com/IAlibay)"
+  - "[Oliver Beckstein](https://github.com/orbeckst)
+  - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"

--- a/_data/team/roles/external_liaison.yml
+++ b/_data/team/roles/external_liaison.yml
@@ -6,5 +6,5 @@ tasks:
 
 current_members:
   - "[Irfan Alibay](https://github.com/IAlibay)"
-  - "[Oliver Beckstein](https://github.com/orbeckst)
+  - "[Oliver Beckstein](https://github.com/orbeckst)"
   - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"

--- a/_data/team/roles/mdakit_registry.yml
+++ b/_data/team/roles/mdakit_registry.yml
@@ -5,8 +5,8 @@ tasks:
   - Managing automated test and badge infrastructure of all MDAKits
   - Manage helping with MDAKits who need assistance
 current_members:
-  - [Irfan Alibay](https://github.com/IAlibay)
-  - [Fiona Naughton](https://github.com/fiona-naughton)
-  - [Lily Wang](https://github.com/lilyminium)
-  - [Oliver Beckstein](https://github.com/orbeckst)
+  - "[Irfan Alibay](https://github.com/IAlibay)"
+  - "[Fiona Naughton](https://github.com/fiona-naughton)"
+  - "[Lily Wang](https://github.com/lilyminium)"
+  - "[Oliver Beckstein](https://github.com/orbeckst)"
 

--- a/_data/team/roles/mdakit_registry.yml
+++ b/_data/team/roles/mdakit_registry.yml
@@ -5,8 +5,8 @@ tasks:
   - Managing automated test and badge infrastructure of all MDAKits
   - Manage helping with MDAKits who need assistance
 current_members:
-  - Irfan Alibay
-  - Fiona Naughton
-  - Lily Wang
-  - Oliver Beckstein
+  - Irfan Alibay (https://github.com/IAlibay)
+  - Fiona Naughton (https://github.com/fiona-naughton)
+  - Lily Wang (https://github.com/lilyminium)
+  - Oliver Beckstein (https://github.com/orbeckst)
 

--- a/_data/team/roles/mdakit_registry.yml
+++ b/_data/team/roles/mdakit_registry.yml
@@ -9,4 +9,6 @@ current_members:
   - "[Fiona Naughton](https://github.com/fiona-naughton)"
   - "[Lily Wang](https://github.com/lilyminium)"
   - "[Oliver Beckstein](https://github.com/orbeckst)"
+  - "[Paul Smith](https://github.com/p-j-smith)"
+
 

--- a/_data/team/roles/mdakit_registry.yml
+++ b/_data/team/roles/mdakit_registry.yml
@@ -5,8 +5,8 @@ tasks:
   - Managing automated test and badge infrastructure of all MDAKits
   - Manage helping with MDAKits who need assistance
 current_members:
-  - Irfan Alibay (https://github.com/IAlibay)
-  - Fiona Naughton (https://github.com/fiona-naughton)
-  - Lily Wang (https://github.com/lilyminium)
-  - Oliver Beckstein (https://github.com/orbeckst)
+  - [Irfan Alibay](https://github.com/IAlibay)
+  - [Fiona Naughton](https://github.com/fiona-naughton)
+  - [Lily Wang](https://github.com/lilyminium)
+  - [Oliver Beckstein](https://github.com/orbeckst)
 

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -61,6 +61,7 @@ subroles:
   - subrole: PathSimAnalysis
     current_members:
       - "[Oliver Beckstein](https://github.com/orbeckst)"
+      - "[Irfan Alibay](https://github.com/IAlibay)"
 
   - subrole: waterdynamics
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -49,7 +49,7 @@ subroles:
   
   - subrole: pyedr
     current_members:
-      - [Irfan Alibay](https://github.com/IAlibay)
+      - "[Irfan Alibay](https://github.com/IAlibay)"
 
   - subrole: pytng
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -66,3 +66,4 @@ subroles:
   - subrole: waterdynamics
     current_members:
       - "[Fiona Naughton](https://github.com/fiona-naughton)"
+      - "[Irfan Alibay](https://github.com/IAlibay)"

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -40,8 +40,8 @@ subroles:
   
   - subrole: MDAnalysisData
     current_members:
-      - [Irfan Alibay](https://github.com/IAlibay)
-      - [Oliver Beckstein](https://github.com/orbeckst)
+      - "[Irfan Alibay](https://github.com/IAlibay)"
+      - "[Oliver Beckstein](https://github.com/orbeckst)"
   
   - subrole: mda-xrlib and other utilities
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -19,8 +19,8 @@ subroles:
 
   - subrole: cookiecutter-mdakit
     current_members:
-      - [Lily Wang](https://github.com/lilyminium)
-      - [Irfan Alibay](https://github.com/IAlibay)
+      - "[Lily Wang](https://github.com/lilyminium)"
+      - "[Irfan Alibay](https://github.com/IAlibay)"
 
   - subrole: mda-encore
     current_members: []

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -45,7 +45,7 @@ subroles:
   
   - subrole: mda-xrlib and other utilities
     current_members:
-      - [Irfan Alibay](https://github.com/IAlibay) 
+      - "[Irfan Alibay](https://github.com/IAlibay)"
   
   - subrole: pyedr
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -31,7 +31,7 @@ subroles:
 
   - subrole: benchmarks
     current_members:
-      - [Oliver Beckstein](https://github.com/orbeckst)    
+      - "[Oliver Beckstein](https://github.com/orbeckst)"
 
   - subrole: GridDataFormats
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -27,7 +27,7 @@ subroles:
     
   - subrole: hole2-mdakit
     current_members:
-      - [Lily Wang](https://github.com/lilyminium)    
+      - "[Lily Wang](https://github.com/lilyminium)"
 
   - subrole: benchmarks
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -53,7 +53,7 @@ subroles:
 
   - subrole: pytng
     current_members:
-      - [Hugo MacDermott-Opeskin](https://github.com/hmacdope)
+      - "[Hugo MacDermott-Opeskin](https://github.com/hmacdope)"
 
   - subrole: PathSimAnalysis
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -61,4 +61,4 @@ subroles:
 
   - subrole: waterdynamics
     current_members:
-      - [Fiona Naughton](https://github.com/fiona-naughton)
+      - "[Fiona Naughton](https://github.com/fiona-naughton)"

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -23,6 +23,8 @@ subroles:
 
   - subrole: mda-encore
     current_members:
+      - "[Kristoffer Enøe Johansson](https://github.com/enoee)" (external developer)
+      - "[Kresten Lindorff-Larsen](https://github.com/lindorff-larsen)" (external developer)
       - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"
     
   - subrole: hole2-mdakit

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -20,6 +20,7 @@ subroles:
     current_members:
       - "[Lily Wang](https://github.com/lilyminium)"
       - "[Irfan Alibay](https://github.com/IAlibay)"
+      - "[Paul Smith](https://github.com/p-j-smith)"
 
   - subrole: mda-encore
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -15,7 +15,6 @@ subroles:
     current_members:
       - "[Richard Gowers](https://github.com/richardjgowers)"
       - "[Hugo MacDermott-Opeskin](https://github.com/hmacdope)"
-      - "[Rocco Meli](https://github.com/RMeli)"
 
   - subrole: cookiecutter-mdakit
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -23,7 +23,8 @@ subroles:
       - "[Irfan Alibay](https://github.com/IAlibay)"
 
   - subrole: mda-encore
-    current_members: []
+    current_members:
+    - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"    
     
   - subrole: hole2-mdakit
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -57,7 +57,7 @@ subroles:
 
   - subrole: PathSimAnalysis
     current_members:
-      - [Oliver Beckstein](https://github.com/orbeckst)
+      - "[Oliver Beckstein](https://github.com/orbeckst)"
 
   - subrole: waterdynamics
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -35,8 +35,8 @@ subroles:
 
   - subrole: GridDataFormats
     current_members:
-      - [Irfan Alibay](https://github.com/IAlibay)
-      - [Oliver Beckstein](https://github.com/orbeckst)
+      - "[Irfan Alibay](https://github.com/IAlibay)"
+      - "[Oliver Beckstein](https://github.com/orbeckst)"
   
   - subrole: MDAnalysisData
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -13,9 +13,9 @@ subroles:
 
   - subrole: distopia
     current_members:
-      - [Richard Gowers](https://github.com/richardjgowers)
-      - [Hugo MacDermott-Opeskin](https://github.com/hmacdope)
-      - [Rocco Meli](https://github.com/RMeli)
+      - "[Richard Gowers](https://github.com/richardjgowers)"
+      - "[Hugo MacDermott-Opeskin](https://github.com/hmacdope)"
+      - "[Rocco Meli](https://github.com/RMeli)"
 
   - subrole: cookiecutter-mdakit
     current_members:

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -13,52 +13,52 @@ subroles:
 
   - subrole: distopia
     current_members:
-      - Richard Gowers
-      - Hugo MacDermott-Opeskin
-      - Rocco Meli
+      - [Richard Gowers](https://github.com/richardjgowers)
+      - [Hugo MacDermott-Opeskin](https://github.com/hmacdope)
+      - [Rocco Meli](https://github.com/RMeli)
 
   - subrole: cookiecutter-mdakit
     current_members:
-      - Lily Wang
-      - Irfan Alibay
+      - [Lily Wang](https://github.com/lilyminium)
+      - [Irfan Alibay](https://github.com/IAlibay)
 
   - subrole: mda-encore
     current_members: []
     
   - subrole: hole2-mdakit
     current_members:
-      - Lily Wang    
+      - [Lily Wang](https://github.com/lilyminium)    
 
   - subrole: benchmarks
     current_members:
-      - Oliver Beckstein    
+      - [Oliver Beckstein](https://github.com/orbeckst)    
 
   - subrole: GridDataFormats
     current_members:
-      - Irfan Alibay
-      - Oliver Beckstein
+      - [Irfan Alibay](https://github.com/IAlibay)
+      - [Oliver Beckstein](https://github.com/orbeckst)
   
   - subrole: MDAnalysisData
     current_members:
-      - Irfan Alibay
-      - Oliver Beckstein
+      - [Irfan Alibay](https://github.com/IAlibay)
+      - [Oliver Beckstein](https://github.com/orbeckst)
   
   - subrole: mda-xrlib and other utilities
     current_members:
-      - Irfan Alibay    
+      - [Irfan Alibay](https://github.com/IAlibay) 
   
   - subrole: pyedr
     current_members:
-      - Irfan Alibay
+      - [Irfan Alibay](https://github.com/IAlibay)
 
   - subrole: pytng
     current_members:
-      - Hugo MacDermott-Opeskin
+      - [Hugo MacDermott-Opeskin](https://github.com/hmacdope)
 
   - subrole: PathSimAnalysis
     current_members:
-      - Oliver Beckstein
+      - [Oliver Beckstein](https://github.com/orbeckst)
 
   - subrole: waterdynamics
     current_members:
-      - Fiona Naughton
+      - [Fiona Naughton](https://github.com/fiona-naughton)

--- a/_data/team/roles/non_core_library_maintenance.yml
+++ b/_data/team/roles/non_core_library_maintenance.yml
@@ -24,7 +24,7 @@ subroles:
 
   - subrole: mda-encore
     current_members:
-    - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"    
+      - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"
     
   - subrole: hole2-mdakit
     current_members:

--- a/_data/team/roles/outreach.yml
+++ b/_data/team/roles/outreach.yml
@@ -7,6 +7,7 @@ subroles:
     - Gathering and coordinating volunteers
     - Managing content, presentations and teaching at workshops
     current_members:
+      - "[Brady Johnston](https://github.com/bradyajohnston)"
       - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
       - "[Micaela Matta](https://github.com/micaela-matta)"
   
@@ -16,6 +17,7 @@ subroles:
       - Advertising opportunities for mentoring programs
       - Mentoring in structured programs
     current_members:
+      - "[Brady Johnston](https://github.com/bradyajohnston)"
       - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
     
   - subrole: Teaching materials

--- a/_data/team/roles/outreach.yml
+++ b/_data/team/roles/outreach.yml
@@ -23,6 +23,6 @@ subroles:
       - Managing teaching materials on GitHub for workshops and events
       - Maintaining and fixing materials
     current_members:
-      - [Rocco Meli](https://github.com/RMeli)
-      - [Micaela Matta](https://github.com/micaela-matta)
-      - [Jenna Swarthout Goddard](https://github.com/jennaswa)
+      - "[Rocco Meli](https://github.com/RMeli)"
+      - "[Micaela Matta](https://github.com/micaela-matta)"
+      - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"

--- a/_data/team/roles/outreach.yml
+++ b/_data/team/roles/outreach.yml
@@ -7,8 +7,8 @@ subroles:
     - Gathering and coordinating volunteers
     - Managing content, presentations and teaching at workshops
     current_members:
-      - [Jenna Swarthout Goddard](https://github.com/jennaswa)
-      - [Micaela Matta](https://github.com/micaela-matta)
+      - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
+      - "[Micaela Matta](https://github.com/micaela-matta)"
   
   - subrole: Mentoring programs
     tasks:

--- a/_data/team/roles/outreach.yml
+++ b/_data/team/roles/outreach.yml
@@ -16,7 +16,7 @@ subroles:
       - Advertising opportunities for mentoring programs
       - Mentoring in structured programs
     current_members:
-      - [Jenna Swarthout Goddard](https://github.com/jennaswa)
+      - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
     
   - subrole: Teaching materials
     tasks:

--- a/_data/team/roles/outreach.yml
+++ b/_data/team/roles/outreach.yml
@@ -7,8 +7,8 @@ subroles:
     - Gathering and coordinating volunteers
     - Managing content, presentations and teaching at workshops
     current_members:
-      - Jenna Swarthout Goddard
-      - Micaela Matta
+      - [Jenna Swarthout Goddard](https://github.com/jennaswa)
+      - [Micaela Matta](https://github.com/micaela-matta)
   
   - subrole: Mentoring programs
     tasks:
@@ -16,13 +16,13 @@ subroles:
       - Advertising opportunities for mentoring programs
       - Mentoring in structured programs
     current_members:
-      - Jenna Swarthout Goddard
+      - [Jenna Swarthout Goddard](https://github.com/jennaswa)
     
   - subrole: Teaching materials
     tasks:
       - Managing teaching materials on GitHub for workshops and events
       - Maintaining and fixing materials
     current_members:
-      - Rocco Meli
-      - Micaela Matta
-      - Jenna Swarthout Goddard
+      - [Rocco Meli](https://github.com/RMeli)
+      - [Micaela Matta](https://github.com/micaela-matta)
+      - [Jenna Swarthout Goddard](https://github.com/jennaswa)

--- a/_data/team/roles/project_organization.yml
+++ b/_data/team/roles/project_organization.yml
@@ -8,3 +8,4 @@ tasks:
 
 current_members:
   - [Jenna Swarthout Goddard](https://github.com/jennaswa)
+  - [Irfan Alibay](https://github.com/IAlibay)

--- a/_data/team/roles/project_organization.yml
+++ b/_data/team/roles/project_organization.yml
@@ -7,4 +7,4 @@ tasks:
   - Gathering usage and community metrics
 
 current_members:
-  - Jenna Swarthout Goddard
+  - [Jenna Swarthout Goddard](https://github.com/jennaswa)

--- a/_data/team/roles/project_organization.yml
+++ b/_data/team/roles/project_organization.yml
@@ -3,6 +3,7 @@ tasks:
   - Organising meetings
   - Coordinating elections of core developers
   - Onboarding new core developers
+  - Managing access keys for MDAnalysis services/accounts
   - Managing other roles in the organisation and general task lists
   - Gathering usage and community metrics
 

--- a/_data/team/roles/project_organization.yml
+++ b/_data/team/roles/project_organization.yml
@@ -7,5 +7,5 @@ tasks:
   - Gathering usage and community metrics
 
 current_members:
-  - [Jenna Swarthout Goddard](https://github.com/jennaswa)
-  - [Irfan Alibay](https://github.com/IAlibay)
+  - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
+  - "[Irfan Alibay](https://github.com/IAlibay)"

--- a/_data/team/roles/releases_and_deployment.yaml
+++ b/_data/team/roles/releases_and_deployment.yaml
@@ -6,5 +6,5 @@ tasks:
   - Carrying out releases for MDAnalysis project packages
   - Managing released packages on conda-forge and PyPi
 current_members:
-  - [Irfan Alibay](https://github.com/IAlibay)
-  - [Fiona Naughton](https://github.com/fiona-naughton)
+  - "[Irfan Alibay](https://github.com/IAlibay)"
+  - "[Fiona Naughton](https://github.com/fiona-naughton)"

--- a/_data/team/roles/releases_and_deployment.yaml
+++ b/_data/team/roles/releases_and_deployment.yaml
@@ -8,3 +8,4 @@ tasks:
 current_members:
   - "[Irfan Alibay](https://github.com/IAlibay)"
   - "[Fiona Naughton](https://github.com/fiona-naughton)"
+  - "[Paul Smith](https://github.com/p-j-smith)"

--- a/_data/team/roles/releases_and_deployment.yaml
+++ b/_data/team/roles/releases_and_deployment.yaml
@@ -6,5 +6,5 @@ tasks:
   - Carrying out releases for MDAnalysis project packages
   - Managing released packages on conda-forge and PyPi
 current_members:
-  - Irfan Alibay
-  - Fiona Naughton
+  - [Irfan Alibay](https://github.com/IAlibay)
+  - [Fiona Naughton](https://github.com/fiona-naughton)

--- a/_data/team/roles/relicensing_coordinator.yml
+++ b/_data/team/roles/relicensing_coordinator.yml
@@ -7,5 +7,5 @@ tasks:
   - Managing the switch to a new license
 
 current_members:
-  - [Irfan Alibay](https://github.com/IAlibay)
-  - [Oliver Beckstein](https://github.com/orbeckst)
+  - "[Irfan Alibay](https://github.com/IAlibay)"
+  - "[Oliver Beckstein](https://github.com/orbeckst)"

--- a/_data/team/roles/relicensing_coordinator.yml
+++ b/_data/team/roles/relicensing_coordinator.yml
@@ -7,5 +7,5 @@ tasks:
   - Managing the switch to a new license
 
 current_members:
-  - Irfan Alibay
-  - Oliver Beckstein
+  - [Irfan Alibay](https://github.com/IAlibay)
+  - [Oliver Beckstein](https://github.com/orbeckst)

--- a/_data/team/roles/social_media.yml
+++ b/_data/team/roles/social_media.yml
@@ -3,7 +3,7 @@ tasks:
   - General management and administration
   - Posting announcements of new developments
   - Moderating content
-  - Managing X and LinkedIn
+  - Managing X, LinkedIn, and Bluesky
   - Managing new content to the MDAnalysis website and blog
 current_members:
-  - Jenna Swarthout Goddard
+  - [Jenna Swarthout Goddard](https://github.com/jennaswa)

--- a/_data/team/roles/social_media.yml
+++ b/_data/team/roles/social_media.yml
@@ -6,4 +6,4 @@ tasks:
   - Managing X, LinkedIn, and Bluesky
   - Managing new content to the MDAnalysis website and blog
 current_members:
-  - [Jenna Swarthout Goddard](https://github.com/jennaswa)
+  - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"

--- a/_includes/team_table.html
+++ b/_includes/team_table.html
@@ -49,6 +49,5 @@
 
 <sup id="current-team-explanation">
     <b><a href="#current-team-heading">Current team:</a></b>
-    This lists all those who are currently responsible for a particular role,
-    from November 14th 2023 to November 14th 2024.
+    This lists all those who are currently responsible for a particular role and was last updated on January 27, 2025.
 </sup>


### PR DESCRIPTION
Per the discussion in https://github.com/MDAnalysis/MDAnalysis.github.io/issues/397, the main purpose of this PR is to:

- [x] List mdanalysis@numfocus.org as a general contact email, and
- [x] Link github profiles to listed team members

In addition, this would provide a good opportunity to update team members in preparation for our first upcoming [R&R review](https://docs.google.com/document/d/1EcC7Y3pJY9aoB2nSJAo6hMd_55p8su7wHrXohVv-qTI/edit?usp=sharing), as decided in the [Aug 20 business meeting](https://docs.google.com/document/d/1SLS8v1_pxYEYha9_3LqjuGE4Q6DC6SeJ722gNy3iHrU/edit?usp=sharing). Namely:

- [ ] Could all @MDAnalysis/coredevs please briefly review what teams you are listed for and make any necessary updates?
- [x] I (@jennaswa) am currently the only listed team member for "Community Engagement". However, in [the way we have defined the Community Engagement role](https://www.mdanalysis.org/pages/team/#community-engagement), I feel others are actually doing this work rather than me (e.g., @hmacdope, @orbeckst, @IAlibay, @RMeli, @yuxuanzhuang, @richardjgowers). Please add your names if you agree.
- [x] Similarly, @IAlibay, as you are doing the majority of the metric tracking (and have tentatively volunteered to help with meetings during my leave), would you like to be listed for the [Project Org & Mgmt role](https://www.mdanalysis.org/pages/team/#project-organization-and-management)?
- [x] @yuxuanzhuang - this seems the perfect opportunity to please add your name to roles you are currently taking on/interested in staying/getting involved with :)

Thanks!