### PR TITLE
Add Markdown support for team members

### DIFF
--- a/_data/team/roles/code_of_conduct.yml
+++ b/_data/team/roles/code_of_conduct.yml
@@ -8,6 +8,6 @@ tasks:
   - Periodically review, revise and update current code of conduct procedures
 
 current_members:
-  - Jenna Swarthout Goddard
+  - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
   - Richard Gowers
   - Micaela Matta

--- a/_includes/team_table_member_cell.html
+++ b/_includes/team_table_member_cell.html
@@ -13,9 +13,9 @@ we need to create empty arrays to avoid errors on concatenating. -->
 {%- for member in sorted_names -%}
     <!-- Bold the name if they're a lead -->
     {%- if leads contains member -%}
-        <b>{{ member }}</b>
+        <b>{{ member | markdownify}}</b>
     {%- else -%}
-        {{ member }}
+        {{ member | markdownify}}
     {%- endif -%}
     <!-- Add a comma if not the last item.
     The % and %- denote leaving a space or not leaving a space

--- a/_includes/team_table_member_cell.html
+++ b/_includes/team_table_member_cell.html
@@ -10,12 +10,13 @@ we need to create empty arrays to avoid errors on concatenating. -->
 
 {% assign all_members = leads | concat: members %}
 {% assign sorted_names = all_members | sort %}
+<!-- markdownify to allow markdown, but remove additional <p> tags this adds -->
 {%- for member in sorted_names -%}
     <!-- Bold the name if they're a lead -->
     {%- if leads contains member -%}
-        <b>{{ member | markdownify}}</b>
+        <b>{{ member | markdownify | strip_newlines | remove: '<p>' | remove: '</p>'}}</b>
     {%- else -%}
-        {{ member | markdownify}}
+        {{ member | markdownify | strip_newlines | remove: '<p>' | remove: '</p>'}}
     {%- endif -%}
     <!-- Add a comma if not the last item.
     The % and %- denote leaving a space or not leaving a space


### PR DESCRIPTION
This PR adds markdown support for links, etc. as necessary for #402 

Please note that the YAML must still be valid (as shown in the example), so a link must be encased in quotes to be interpreted as a string item of a list.