### PR TITLE
remove UGM 2024 from landing page

### DIFF
--- a/index.md
+++ b/index.md
@@ -70,7 +70,6 @@ forum]({{ site.mailinglists.developer.url }}).
 
 MDAnalysis regularly takes part in various **mentoring and outreach programs**, such as [Google Summer of Code](https://summerofcode.withgoogle.com/), [Google Season of Docs](https://developers.google.com/season-of-docs), [Outreachy](https://www.outreachy.org/), the [Station1 Frontiers Fellowship](https://www.station1.org/sff), and the [CompChemURG](https://www.bindingsites.co.uk/home) mentorship schemes. Many of the [current core developers](/about/#mdanalysis-core-developers/) joined the project through these mentoring schemes. The project also frequently offers **teaching workshops**, both online and in-person; recordings are often made available on the [MDAnalysis YouTube channel](https://www.youtube.com/@mdanalysis3040). Follow our [blog]({{ site.baseurl }}/blog), [LinkedIn](https://www.linkedin.com/company/mdanalysis/), [Twitter](https://twitter.com/mdanalysis), and [Bluesky](https://bsky.app/profile/mdanalysis.bsky.social) pages for updates on how to participate.
 
-To **connect with other MDAnalysis users, present your work using MDAnalysis, and meet the developer team,** join us August 21-23, 2024 for our [User Group Meeting]({{ site.baseurl }}/pages/ugm2024/) in London, United Kingdom.  
 
 ## Supporting ##
 


### PR DESCRIPTION
The landing page is still encouraging registration for UGM 2024, which is now 3 months in the past. This PR updates our top-level page.