### PR TITLE
Teams: Integrate 'social media' into 'community engagement' tasks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -76,6 +76,12 @@ mailinglists:
 twitter:
   name:           mdanalysis
   url:            https://twitter.com/mdanalysis
+linkedin:
+  name:           mdanalysis
+  url:            https://linkedin.com/company/mdanalysis
+bluesky:
+  name:           mdanalysis.bsky.social
+  url:            https://bsky.app/profile/mdanalysis.bsky.social
 discord:
   name:           MDAnalysis
   url:            https://discord.com/channels/807348386012987462/

--- a/_data/team/roles/community_engagement.yml
+++ b/_data/team/roles/community_engagement.yml
@@ -3,8 +3,8 @@ tasks:
   - Responding to questions on [Discord]({{ site.discord.url }}) and [GitHub Discussions]({{ site.mailinglists.discussion.url }})
   - Managing and triaging conversations on [Discord]({{ site.discord.url }}) and [GitHub Discussions]({{ site.mailinglists.discussion.url }})
   - General management and administration of social accounts (i.e., [LinkedIn]({{ site.linkedin.url}}), [Bluesky]({{ site.bluesky.url }})), [website]({{ site.url }}), and [blog]({{ site.blog }}), including...
-  - *Posting announcements of new developments*
-  - *Moderating content*
+    - *Posting announcements of new developments*
+    - *Moderating content*
 
 current_members:
   - "[Brady Johnston](https://github.com/bradyajohnston)"

--- a/_data/team/roles/community_engagement.yml
+++ b/_data/team/roles/community_engagement.yml
@@ -1,7 +1,10 @@
 role: Community engagement
 tasks: 
-  - Responding to questions on Discord and GitHub Discussions
-  - Managing and triaging conversations on Discord and GitHub Discussions
+  - Responding to questions on [Discord]({{ site.discord.url }}) and [GitHub Discussions]({{ site.mailinglists.discussion.url }})
+  - Managing and triaging conversations on [Discord]({{ site.discord.url }}) and [GitHub Discussions]({{ site.mailinglists.discussion.url }})
+  - General management and administration of social accounts (i.e., [LinkedIn]({{ site.linkedin.url}}), [Bluesky]({{ site.bluesky.url }})), [website]({{ site.url }}), and [blog]({{ site.blog }}), including...
+  - *Posting announcements of new developments*
+  - *Moderating content*
 
 current_members:
   - "[Brady Johnston](https://github.com/bradyajohnston)"

--- a/_data/team/roles/social_media.yml
+++ b/_data/team/roles/social_media.yml
@@ -1,9 +1,0 @@
-role: Social media
-tasks: 
-  - General management and administration
-  - Posting announcements of new developments
-  - Moderating content
-  - Managing X, LinkedIn, and Bluesky
-  - Managing new content to the MDAnalysis website and blog
-current_members:
-  - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"


### PR DESCRIPTION
Based on our team reviews, I proposed combining the social media and community engagement teams. This PR therefore:

- Incorporates the social media tasks into the community engagement task list
- Removes the social media team
- Adds links to relevant profiles referenced

Note that the following items are up for discussion at the 02-24-24 business meeting, and may influence this PR.

- Whether to keep the MDAnalysis X account. X is currently excluded from the list of profiles in this PR.
- Whether AO is interested in helping to manage content for the socials/blog. If so, we should add her as a team member.