### PR TITLE
Teams: Integrate 'teaching materials' into 'workshops and meetings' tasks

### DIFF
--- a/_data/team/roles/outreach.yml
+++ b/_data/team/roles/outreach.yml
@@ -12,7 +12,9 @@ subroles:
       - "[Brady Johnston](https://github.com/bradyajohnston)"
       - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
       - "[Micaela Matta](https://github.com/micaela-matta)"
+      - "[Richard Gowers](https://github.com/richardjgowers)"
       - "[Rocco Meli](https://github.com/RMeli)"
+      - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"
   
   - subrole: Mentoring programs
     tasks:

--- a/_data/team/roles/outreach.yml
+++ b/_data/team/roles/outreach.yml
@@ -12,7 +12,6 @@ subroles:
       - "[Brady Johnston](https://github.com/bradyajohnston)"
       - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
       - "[Micaela Matta](https://github.com/micaela-matta)"
-      - "[Richard Gowers](https://github.com/richardjgowers)"
       - "[Rocco Meli](https://github.com/RMeli)"
       - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"
   

--- a/_data/team/roles/outreach.yml
+++ b/_data/team/roles/outreach.yml
@@ -6,10 +6,13 @@ subroles:
     - Organising workshops and events
     - Gathering and coordinating volunteers
     - Managing content, presentations and teaching at workshops
+    - Managing teaching materials on GitHub for workshops and events
+    - Maintaining and fixing materials
     current_members:
       - "[Brady Johnston](https://github.com/bradyajohnston)"
       - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
       - "[Micaela Matta](https://github.com/micaela-matta)"
+      - "[Rocco Meli](https://github.com/RMeli)"
   
   - subrole: Mentoring programs
     tasks:
@@ -21,12 +24,3 @@ subroles:
       - "[Egor Marin](https://github.com/marinegor)"
       - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
       - "[Google Summer of Code (GSoC) mentors](https://github.com/MDAnalysis/mdanalysis/wiki/Google-Summer-Of-Code#available-mentors)"
-    
-  - subrole: Teaching materials
-    tasks:
-      - Managing teaching materials on GitHub for workshops and events
-      - Maintaining and fixing materials
-    current_members:
-      - "[Rocco Meli](https://github.com/RMeli)"
-      - "[Micaela Matta](https://github.com/micaela-matta)"
-      - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"

--- a/_data/team/roles/outreach.yml
+++ b/_data/team/roles/outreach.yml
@@ -2,7 +2,7 @@ role: Outreach
 subroles:
   - subrole: Workshops and meetings
     tasks:
-    - Identifying workshop and event opportunities
+    - Identifying workshop and event opportunities and sponsors
     - Organising workshops and events
     - Gathering and coordinating volunteers
     - Managing content, presentations and teaching at workshops


### PR DESCRIPTION
Our team reviews revealed that the "Teaching materials" and "Workshops and meetings" teams were really one in the same. This PR therefore:

- Incorporates the teaching materials tasks into the workshops and meetings task list
- Removes the teaching materials team
- Proposes adding @richardjgowers and @yuxuanzhuang to the team based on their substantial contributions
- Adds 'identifying sponsors' as an inherent task related to organizing events

Note that processes for archiving workshop materials are up for discussion at the 02-24-24 business meeting, and may influence this PR. Additionally, as NO's work on the SDG docs project will likely touch the teaching material organization, it will likely make sense to add her as a team member as well.