### PR TITLE
Teams: Add Micaela and Yuxuan to external liaison team

### DIFF
--- a/_data/team/roles/external_liaison.yml
+++ b/_data/team/roles/external_liaison.yml
@@ -6,5 +6,7 @@ tasks:
 
 current_members:
   - "[Irfan Alibay](https://github.com/IAlibay)"
-  - "[Oliver Beckstein](https://github.com/orbeckst)"
   - "[Jenna Swarthout Goddard](https://github.com/jennaswa)"
+  - "[Micaela Matta](https://github.com/micaela-matta)"
+  - "[Oliver Beckstein](https://github.com/orbeckst)"
+  - "[Yuxuan Zhuang](https://github.com/yuxuanzhuang)"


### PR DESCRIPTION
In the latest round of team reviews, I proposed adding @micaela-matta and @yuxuanzhuang to the External Liaison team based on their past contributions to securing sponsorships for events (MM) and participation in the NF project summit and collabs with other projects (e.g., Molecular Nodes) (YZ).

Additionally, @IAlibay brought up the question of @MDAnalysis/coredevs expectations in terms of reporting back on liaisons (e.g., emails or summaries in other formats after meetings). If there is a desire for this, perhaps it makes sense to add this explicitly as a responsibility.