### PR TITLE
Teams: Rephrase task on helping with specific MDAKits

### DIFF
--- a/_data/team/roles/mdakit_registry.yml
+++ b/_data/team/roles/mdakit_registry.yml
@@ -3,7 +3,7 @@ tasks:
   - Managing submissions to MDAKits registry
   - Managing manual review process of new MDAKits
   - Managing automated test and badge infrastructure of all MDAKits
-  - Offer input on MDAKit issues where possible
+  - Offer input on failures due to the MDAKit registry
 current_members:
   - "[Irfan Alibay](https://github.com/IAlibay)"
   - "[Fiona Naughton](https://github.com/fiona-naughton)"

--- a/_data/team/roles/mdakit_registry.yml
+++ b/_data/team/roles/mdakit_registry.yml
@@ -3,7 +3,7 @@ tasks:
   - Managing submissions to MDAKits registry
   - Managing manual review process of new MDAKits
   - Managing automated test and badge infrastructure of all MDAKits
-  - Manage helping with MDAKits who need assistance
+  - Offer input on MDAKit issues where possible
 current_members:
   - "[Irfan Alibay](https://github.com/IAlibay)"
   - "[Fiona Naughton](https://github.com/fiona-naughton)"


### PR DESCRIPTION
From team reviews: “Manage helping with MDAKits who need assistance” is an unclear goal, and possibly an unrealistic one as the registry grows. We suggest rephrasing the responsibility to “offer input on MDAKit issues where possible” as a more realistic responsibility.

Relatedly, we will need to develop a post-EOSS4 plan to ensure the registry is maintained.