### PR TITLE
Teams: Clarify that sub-project managers are also responsible for maintenance

### DIFF
--- a/_data/team/roles/core_library_maintenance.yml
+++ b/_data/team/roles/core_library_maintenance.yml
@@ -33,8 +33,9 @@ subroles:
   
   - subrole: General maintenance
     tasks:
-      - Monitoring and acting on maintenance needs across the MDAnalysis ecosystem
-      - Standards compliance (e.g. managing metadata such as the author list)
+      - Monitoring maintenance needs across the MDAnalysis ecosystem
+      - Acting on maintenance needs, or delegating to appropriate managers of sub-projects, as necessary
+      - Standards compliance (e.g., managing metadata such as the author list)
       - Tracking new dependencies
       - Emergency fixes
       - Other general maintenance tasks


### PR DESCRIPTION
From team reviews: The wording of the responsibilities list seems to indicate that the persons on this team are responsible for maintaining the entire ecosystem. It should be made clear that folks that are responsible for a specific sub-part of the ecosystem should be responsible for maintaining them.