### PR TITLE
Teams: Add Namir to documentation team

### DIFF
--- a/_data/team/roles/documentation.yml
+++ b/_data/team/roles/documentation.yml
@@ -11,6 +11,7 @@ current_members:
   - "[Egor Marin](https://github.com/marinegor)"
   - "[Irfan Alibay](https://github.com/IAlibay)"
   - "[Lily Wang](https://github.com/lilyminium)"
+  - "[Namir Oues](https://github.com/namiroues) (technical writer)"
   - "[Rocco Meli](https://github.com/RMeli)"
 
 

--- a/_data/team/roles/documentation.yml
+++ b/_data/team/roles/documentation.yml
@@ -11,7 +11,8 @@ current_members:
   - "[Egor Marin](https://github.com/marinegor)"
   - "[Irfan Alibay](https://github.com/IAlibay)"
   - "[Lily Wang](https://github.com/lilyminium)"
+  - "[Micaela Matta](https://github.com/micaela-matta)"
   - "[Namir Oues](https://github.com/namiroues) (technical writer)"
+  - "[Oliver Beckstein](https://github.com/orbeckst)"
   - "[Rocco Meli](https://github.com/RMeli)"
-
-
+  


### PR DESCRIPTION
As our new Technical Writer for the SDG documentation project, it would be great to officially add @namiroues on the MDAnalysis team page :)