### PR TITLE
GSOC 2025 blog post fixes

### DIFF
--- a/_posts/2025-02-28-gsoc2025.md
+++ b/_posts/2025-02-28-gsoc2025.md
@@ -122,11 +122,13 @@ Submit your pre-proposal via [this submission form][submission form] **as soon a
 * **Approach:** Describe how you are going to reach your goal (i.e., answer the overarching question). Which algorithms are you going to use? Are there any libraries or other packages you want to use? Do you need to research different solutions? Be as concrete as possible; you want to convince your audience that it is feasible to solve this problem and you have an idea how to tackle it.
 * **Objectives:** Use a numbered list to state 3–5 measurable non-trivial outcomes that you need to achieve in order to reach the overall goal. These are the milestones that you have to reach; they are possibly dependent on each other. For each objective it must be clear how to decide if you fulfilled it or not. Objectives are formulated in terms of actions and deliverables.
 
-### Have a pull request merged (*if you are invited to based on your pre-proposal*)
+### Have a pull request merged (*by invitation*)
 
-GSoC contributors with MDAnalysis will need to demonstrate that they have been seriously engaged with the MDAnalysis project and/or the partner software projects (WESTPA, Molecular Nodes, ProLIF) by having a pull request (PR) merged *prior* to submitting their full GSoC application on the [GSoC website][gsoc]. Submit the PR in one of the repositories under the MDAnalysis org (https://github.com/MDAnalysis/) or, for projects related to Molecular Nodes (i.e., [Project 4]({{ site.github.wiki }}/GSoC-2025-Project-Ideas#project-4-better-interfacing-of-blender-and-mdanalysis)) or ProLIF (i.e., [Project 5]({{ site.github.wiki }}/GSoC-2025-Project-Ideas#project-5-hbond-interactions-from-implicit-hydrogens), [Project 6]({{ site.github.wiki }}/GSoC-2025-Project-Ideas#project-6-continuous-ie-non-binary-interaction-fingerprints-ifps), [Project 7]({{ site.github.wiki }}/GSoC-2025-Project-Ideas#project-7-improving-prolifs-2d-interaction-visualizations)), in the relevant repositories (MolecularNodes [https://github.com/BradyAJohnston/MolecularNodes], ProLIF [https://github.com/chemosim-lab/ProLIF]). 
+Based on your **pre-proposal** we may invite you to contribute a pull request.
 
-You must have *at least one commit* merged in one of the organizations to be eligible. Note that **the earlier you submit your pre-proposal (which are reviewed on a rolling basis), the more time you may have to work on having code merged!**   
+GSoC contributors with MDAnalysis will need to demonstrate that they have been seriously engaged with the MDAnalysis project and/or the partner software projects (WESTPA, Molecular Nodes, ProLIF) by **having a pull request (PR) merged *prior* to submitting their full GSoC application** on the [GSoC website][gsoc]. Submit the PR in one of the repositories under the [MDAnalysis org](https://github.com/MDAnalysis/) or, for projects related to Molecular Nodes (i.e., [Project 4]({{ site.github.wiki }}/GSoC-2025-Project-Ideas#project-4-better-interfacing-of-blender-and-mdanalysis)) or ProLIF (i.e., [Project 5]({{ site.github.wiki }}/GSoC-2025-Project-Ideas#project-5-hbond-interactions-from-implicit-hydrogens), [Project 6]({{ site.github.wiki }}/GSoC-2025-Project-Ideas#project-6-continuous-ie-non-binary-interaction-fingerprints-ifps), [Project 7]({{ site.github.wiki }}/GSoC-2025-Project-Ideas#project-7-improving-prolifs-2d-interaction-visualizations)), in the relevant repositories (MolecularNodes: [BradyAJohnston/MolecularNodes](https://github.com/BradyAJohnston/MolecularNodes), ProLIF: [chemosim-lab/ProLIF](https://github.com/chemosim-lab/ProLIF)).
+
+You must have *at least one commit* merged in one of the organizations to be eligible. Note that **the earlier you submit your pre-proposal (which are reviewed on a rolling basis), the more time you may have to work on having code merged!**
 
 We have a list of [easy bugs] and
 suggested [GSOC Starter issues][GSOC Starter] to work on in our issue tracker
@@ -141,9 +143,7 @@ about setting up a development environment or how to contribute.
 
 **Submit your pre-proposal before March 21, 2025**, but the earlier the better! We will then let you know via the email you provide in the [pre-proposal submission form][submission form] if you have been selected to attempt an issue on GitHub and ultimately submit a full application; we strive to inform you of a decision within a week of your submission. The GSoC contributor application period opens on March 24, 2025.
 
-Feel free to ask any questions on the [discussion forum]. We are also happy to chat on our [{{ site.discord.name }} Discord
-server][discord] in the `#gsoc` channel (join with the public
-[invitation link]({{ site.baseurl }}/#participating)).
+Feel free to ask any questions on the [discussion forum]. We are also happy to chat on our [{{ site.discord.name }} Discord server][discord] in the `#gsoc` channel (join with the public [invitation link]({{ site.baseurl }}/#participating)). Please note that MDAnalysis as an organization highly values transparency and therefore we strive to *conduct all discussions in public forums* so please ask questions publicly and not via direct messages or emails.
 
 We look forward to working with you in GSoC 2025!
 


### PR DESCRIPTION
- fixed links for orgs
- added sentence that we do not want DMs or private emails: transparency as a value