### PR TITLE
Fix YAML syntax error in current_members list

### DIFF
--- a/_data/team/roles/releases_and_deployment.yaml
+++ b/_data/team/roles/releases_and_deployment.yaml
@@ -9,4 +9,4 @@ current_members:
   - "[Irfan Alibay](https://github.com/IAlibay)"
   - "[Fiona Naughton](https://github.com/fiona-naughton)"
   - "[Paul Smith](https://github.com/p-j-smith)"
-  = "[Hugo MacDermott-Opeskin](https://github.com/hmacdope)"
+  - "[Hugo MacDermott-Opeskin](https://github.com/hmacdope)"


### PR DESCRIPTION
This PR fixes #453. 
