### PR TITLE
Update NF CoC reporting form link

### DIFF
--- a/_data/team/roles/code_of_conduct.yml
+++ b/_data/team/roles/code_of_conduct.yml
@@ -1,11 +1,11 @@
 role: Code of conduct committee
 description: |
-  The [code of conduct]({{ site.baseurl }}/conduct/) committee members
-  are elected by the [project leadership]({{ site.baseurl }}/pages/governance/) when a committee members' term limit (2 years) has expired.
+  The [code of conduct](https://www.mdanalysis.org/conduct/) committee members
+  are elected by the [project leadership](https://www.mdanalysis.org/pages/governance/) when a committee members' term limit (2 years) has expired.
 tasks: 
   - Ensure that the application of the code of conduct remains up-to-date, reflecting any changes from the NumFOCUS and MDAnalysis communities
-  - Coordinate with and defer to the [NumFOCUS Code of Conduct Working Group]({{ site.baseurl }}/conduct/#who-will-receive-your-report) for complaints/violation reports and initial recommendations
-  - Propose actions and sanctions, as necessary, to the [project leadership]({{ site.baseurl }}/pages/governance/), original reporter, and any other affeccted parties (project leadership is tasked with enforcement)
+  - Coordinate with and defer to the [NumFOCUS Code of Conduct Working Group](https://www.mdanalysis.org/conduct/#who-will-receive-your-report) for complaints/violation reports and initial recommendations
+  - Propose actions and sanctions, as necessary, to the [project leadership](https://www.mdanalysis.org/pages/governance/), original reporter, and any other affeccted parties (project leadership is tasked with enforcement)
   - Keep confidential records of how reported incidents were handled
 
 current_members:

--- a/_data/team/roles/community_engagement.yml
+++ b/_data/team/roles/community_engagement.yml
@@ -1,8 +1,9 @@
 role: Community engagement
 tasks: 
-  - Responding to questions on [Discord]({{ site.discord.url }}) and [GitHub Discussions]({{ site.mailinglists.discussion.url }})
-  - Managing and triaging conversations on [Discord]({{ site.discord.url }}) and [GitHub Discussions]({{ site.mailinglists.discussion.url }})
-  - General management and administration of social accounts (i.e., [LinkedIn]({{ site.linkedin.url}}), [Bluesky]({{ site.bluesky.url }})), [website]({{ site.url }}), and [blog]({{ site.blog }}), including...
+  - Responding to questions on [Discord](https://discord.com/channels/807348386012987462/) and [GitHub Discussions](https://github.com/MDAnalysis/mdanalysis/discussions)
+  - Managing and triaging conversations on [Discord](https://discord.com/channels/807348386012987462/) and [GitHub Discussions](https://github.com/MDAnalysis/mdanalysis/discussions)
+  - General management and administration of social accounts (i.e., [LinkedIn](https://linkedin.com/company/mdanalysis), [Bluesky](https://bsky.app/profile/mdanalysis.bsky.social)), [website](https://www.mdanalysis.org), and [blog](https://www.mdanalysis.org/blog/), including...
+    
     - *Posting announcements of new developments*
     - *Moderating content*
 

--- a/conduct.md
+++ b/conduct.md
@@ -46,7 +46,7 @@ You can find the long version of the Code of Conduct on the NumFOCUS website:
 
 ## HOW TO REPORT
 If you feel that the Code of Conduct has been violated, feel free to submit a report, by
-using the [NumFOCUS Code of Conduct Reporting Form](https://numfocus.typeform.com/to/ynjGdT?typeform-source=numfocus.org).
+using the [NumFOCUS Code of Conduct Reporting Form](https://forms.monday.com/forms/f130e8cddb99568fa86cf077b8912a60?r=use1).
 
 ### REPORTING AT MDANALYSIS EVENTS AND MEETUPS
 If you are attending an MDAnalysis event or meetup and wish to make a report that requires


### PR DESCRIPTION
Per communications from NumFOCUS, we have been asked to update the link to NumFOCUS's Code of Conduct Reporting Form (see below):

> We’re reaching out to ask that you update the Code of Conduct reporting form link anywhere it appears in your project’s digital assets, including your website, GitHub repositories, documentation, community spaces, and communications channels.

> We are making this request because NumFOCUS is moving off of Typeform in early July 2026, and we want to make sure community members are directed to the correct reporting form before that transition happens.

> Please replace the current Typeform link with the new reporting form link here:

> [New monday.com reporting form](https://forms.monday.com/forms/f130e8cddb99568fa86cf077b8912a60?r=use1)

This PR:
- Makes this requested update to the CoC reporting form link, and
- Temporarily fixes some broken links I identified on https://www.mdanalysis.org/team/ (see https://github.com/MDAnalysis/MDAnalysis.github.io/issues/505).