### PR TITLE
Fix MN image link in workshop post

### DIFF
--- a/_posts/2026-08-18-molecularnodes-workshop.md
+++ b/_posts/2026-08-18-molecularnodes-workshop.md
@@ -8,7 +8,7 @@ Nodes](https://bradyajohnston.github.io/MolecularNodes/) workshop** at
 King's College London on **September 17–18, 2026**. Registration is
 free, with 30 spots available — apply by **September 4, 2026**.
 
-  <img src="{{ site.images }}/public/images/blender-molecular-nodes.png"
+  <img src="{{ site.images }}/blender-molecular-nodes.png"
    style="float: right" alt="alternative text" width="30%"/>
 
 ## What Is Molecular Nodes?


### PR DESCRIPTION
Hi @BradyAJohnston, the image link isn't correct and hence now showing up:

<img width="895" height="497" alt="image" src="https://github.com/user-attachments/assets/029f598e-c316-4988-ad7f-df8931323d14" />

Fixed it in this PR. Thanks

<img width="898" height="588" alt="image" src="https://github.com/user-attachments/assets/3262ee3e-1c56-4ba7-8f5d-21515e0f8539" />

